### PR TITLE
🔀 :: 9 - 아티스트와 뮤직 엔티티의 연관관계 수정

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { ConfigModule } from "@nestjs/config";
 import { Artist } from "./domain/artist/entity/artist.entity";
 import { ArtistGenerator } from "./domain/artist/generator/artist.generator";
 import { Music } from "./domain/music/entity/music.entity";
+import { Participant } from "./domain/participant/entity/participant.entity";
 
 @Module({
   imports: [
@@ -18,7 +19,7 @@ import { Music } from "./domain/music/entity/music.entity";
       username: process.env.DATABASE_USERNAME,
       password: process.env.DATABASE_PASSWORD,
       database: process.env.DATABASE_NAME,
-      entities: [Artist, Music],
+      entities: [Artist, Music, Participant],
       synchronize: true
     }),
     TypeOrmModule.forFeature([Artist])

--- a/src/domain/music/entity/music.entity.ts
+++ b/src/domain/music/entity/music.entity.ts
@@ -1,5 +1,4 @@
-import { Artist } from "src/domain/artist/entity/artist.entity";
-import { Column, Entity, ManyToOne, PrimaryColumn } from "typeorm";
+import { Column, Entity, PrimaryColumn } from "typeorm";
 
 @Entity()
 export class Music {
@@ -23,7 +22,4 @@ export class Music {
 
   @Column()
   KYKaraokeCode: number;
-
-  @ManyToOne(() => Artist)
-  artist: Artist;
 }

--- a/src/domain/participant/entity/participant.entity.ts
+++ b/src/domain/participant/entity/participant.entity.ts
@@ -1,0 +1,15 @@
+import { Artist } from "src/domain/artist/entity/artist.entity";
+import { Music } from "src/domain/music/entity/music.entity";
+import { Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity()
+export class Participant {
+  @PrimaryGeneratedColumn()
+  readonly id: number;
+
+  @ManyToOne(() => Artist)
+  readonly artist: Artist;
+
+  @ManyToOne(() => Music)
+  readonly music: Music;
+}


### PR DESCRIPTION
## 개요
* 아티스트와 뮤직 엔티티의 연관관계를 수정합니다.
## 작업내용
* Participant 엔티티 추가
* AppModule에 Music 추가
* 기존에 맺어져 있던 Music 엔티티와 Artist 엔티티의 연관관계 제거