### PR TITLE
🔀 :: 11 - 차트 엔티티 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,9 @@ import { Artist } from "./domain/artist/entity/artist.entity";
 import { ArtistGenerator } from "./domain/artist/generator/artist.generator";
 import { Music } from "./domain/music/entity/music.entity";
 import { Participant } from "./domain/participant/entity/participant.entity";
+import { ChartOfWeek } from "./domain/chart/entity/chart-of-week.entity";
+import { ChartOfDay } from "./domain/chart/entity/chart-of-day.entity";
+import { ChartOfHour } from "./domain/chart/entity/chart-of-hour.entity";
 
 @Module({
   imports: [
@@ -19,7 +22,7 @@ import { Participant } from "./domain/participant/entity/participant.entity";
       username: process.env.DATABASE_USERNAME,
       password: process.env.DATABASE_PASSWORD,
       database: process.env.DATABASE_NAME,
-      entities: [Artist, Music, Participant],
+      entities: [Artist, Music, Participant, ChartOfWeek, ChartOfDay, ChartOfHour],
       synchronize: true
     }),
     TypeOrmModule.forFeature([Artist])

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { ChartOfWeek } from "./domain/chart/entity/chart-of-week.entity";
 import { ChartOfDay } from "./domain/chart/entity/chart-of-day.entity";
 import { ChartOfHour } from "./domain/chart/entity/chart-of-hour.entity";
 import { ChartOfMonth } from "./domain/chart/entity/chart-of-month.entity";
+import { ChartOfYear } from "./domain/chart/entity/chart-of-year.entity";
 
 @Module({
   imports: [
@@ -23,7 +24,16 @@ import { ChartOfMonth } from "./domain/chart/entity/chart-of-month.entity";
       username: process.env.DATABASE_USERNAME,
       password: process.env.DATABASE_PASSWORD,
       database: process.env.DATABASE_NAME,
-      entities: [Artist, Music, Participant, ChartOfWeek, ChartOfDay, ChartOfHour, ChartOfMonth],
+      entities: [
+        Artist,
+        Music,
+        Participant,
+        ChartOfWeek,
+        ChartOfDay,
+        ChartOfHour,
+        ChartOfMonth,
+        ChartOfYear
+      ],
       synchronize: true
     }),
     TypeOrmModule.forFeature([Artist])

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { Participant } from "./domain/participant/entity/participant.entity";
 import { ChartOfWeek } from "./domain/chart/entity/chart-of-week.entity";
 import { ChartOfDay } from "./domain/chart/entity/chart-of-day.entity";
 import { ChartOfHour } from "./domain/chart/entity/chart-of-hour.entity";
+import { ChartOfMonth } from "./domain/chart/entity/chart-of-month.entity";
 
 @Module({
   imports: [
@@ -22,7 +23,7 @@ import { ChartOfHour } from "./domain/chart/entity/chart-of-hour.entity";
       username: process.env.DATABASE_USERNAME,
       password: process.env.DATABASE_PASSWORD,
       database: process.env.DATABASE_NAME,
-      entities: [Artist, Music, Participant, ChartOfWeek, ChartOfDay, ChartOfHour],
+      entities: [Artist, Music, Participant, ChartOfWeek, ChartOfDay, ChartOfHour, ChartOfMonth],
       synchronize: true
     }),
     TypeOrmModule.forFeature([Artist])

--- a/src/domain/chart/entity/chart-of-day.entity.ts
+++ b/src/domain/chart/entity/chart-of-day.entity.ts
@@ -2,7 +2,7 @@ import { Music } from "src/domain/music/entity/music.entity";
 import { Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
 
 @Entity()
-export class ChartOfHour {
+export class ChartOfDay {
   @PrimaryGeneratedColumn()
   readonly id: number;
   @ManyToOne(() => Music)

--- a/src/domain/chart/entity/chart-of-day.entity.ts
+++ b/src/domain/chart/entity/chart-of-day.entity.ts
@@ -1,5 +1,5 @@
 import { Music } from "src/domain/music/entity/music.entity";
-import { Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
 
 @Entity()
 export class ChartOfDay {
@@ -8,8 +8,12 @@ export class ChartOfDay {
   @OneToOne(() => Music)
   @JoinColumn()
   readonly music: Music;
+  @Column()
   readonly views: number;
+  @Column()
   readonly ranking: number;
+  @Column()
   readonly rise: number;
+  @Column()
   readonly createdAt: Date;
 }

--- a/src/domain/chart/entity/chart-of-day.entity.ts
+++ b/src/domain/chart/entity/chart-of-day.entity.ts
@@ -10,5 +10,6 @@ export class ChartOfDay {
   readonly music: Music;
   readonly views: number;
   readonly ranking: number;
+  readonly rise: number;
   readonly createdAt: Date;
 }

--- a/src/domain/chart/entity/chart-of-day.entity.ts
+++ b/src/domain/chart/entity/chart-of-day.entity.ts
@@ -1,11 +1,12 @@
 import { Music } from "src/domain/music/entity/music.entity";
-import { Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
 
 @Entity()
 export class ChartOfDay {
   @PrimaryGeneratedColumn()
   readonly id: number;
-  @ManyToOne(() => Music)
+  @OneToOne(() => Music)
+  @JoinColumn()
   readonly music: Music;
   readonly views: number;
   readonly ranking: number;

--- a/src/domain/chart/entity/chart-of-day.entity.ts
+++ b/src/domain/chart/entity/chart-of-day.entity.ts
@@ -1,0 +1,13 @@
+import { Music } from "src/domain/music/entity/music.entity";
+import { Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity()
+export class ChartOfHour {
+  @PrimaryGeneratedColumn()
+  readonly id: number;
+  @ManyToOne(() => Music)
+  readonly music: Music;
+  readonly views: number;
+  readonly ranking: number;
+  readonly createdAt: Date;
+}

--- a/src/domain/chart/entity/chart-of-hour.entity.ts
+++ b/src/domain/chart/entity/chart-of-hour.entity.ts
@@ -1,11 +1,12 @@
 import { Music } from "src/domain/music/entity/music.entity";
-import { Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
 
 @Entity()
 export class ChartOfHour {
   @PrimaryGeneratedColumn()
   readonly id: number;
-  @ManyToOne(() => Music)
+  @OneToOne(() => Music)
+  @JoinColumn()
   readonly music: Music;
   readonly views: number;
   readonly ranking: number;

--- a/src/domain/chart/entity/chart-of-hour.entity.ts
+++ b/src/domain/chart/entity/chart-of-hour.entity.ts
@@ -10,5 +10,6 @@ export class ChartOfHour {
   readonly music: Music;
   readonly views: number;
   readonly ranking: number;
+  readonly rise: number;
   readonly createdAt: Date;
 }

--- a/src/domain/chart/entity/chart-of-hour.entity.ts
+++ b/src/domain/chart/entity/chart-of-hour.entity.ts
@@ -1,5 +1,5 @@
 import { Music } from "src/domain/music/entity/music.entity";
-import { Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
 
 @Entity()
 export class ChartOfHour {
@@ -8,8 +8,12 @@ export class ChartOfHour {
   @OneToOne(() => Music)
   @JoinColumn()
   readonly music: Music;
+  @Column()
   readonly views: number;
+  @Column()
   readonly ranking: number;
+  @Column()
   readonly rise: number;
+  @Column()
   readonly createdAt: Date;
 }

--- a/src/domain/chart/entity/chart-of-hour.entity.ts
+++ b/src/domain/chart/entity/chart-of-hour.entity.ts
@@ -1,0 +1,13 @@
+import { Music } from "src/domain/music/entity/music.entity";
+import { Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity()
+export class ChartOfHour {
+  @PrimaryGeneratedColumn()
+  readonly id: number;
+  @ManyToOne(() => Music)
+  readonly music: Music;
+  readonly views: number;
+  readonly ranking: number;
+  readonly createdAt: Date;
+}

--- a/src/domain/chart/entity/chart-of-month.entity.ts
+++ b/src/domain/chart/entity/chart-of-month.entity.ts
@@ -1,0 +1,19 @@
+import { Music } from "src/domain/music/entity/music.entity";
+import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity()
+export class ChartOfMonth {
+  @PrimaryGeneratedColumn()
+  readonly id: number;
+  @OneToOne(() => Music)
+  @JoinColumn()
+  readonly music: Music;
+  @Column()
+  readonly views: number;
+  @Column()
+  readonly ranking: number;
+  @Column()
+  readonly rise: number;
+  @Column()
+  readonly createdAt: Date;
+}

--- a/src/domain/chart/entity/chart-of-week.entity.ts
+++ b/src/domain/chart/entity/chart-of-week.entity.ts
@@ -1,5 +1,5 @@
 import { Music } from "src/domain/music/entity/music.entity";
-import { Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
 
 @Entity()
 export class ChartOfWeek {
@@ -8,8 +8,12 @@ export class ChartOfWeek {
   @OneToOne(() => Music)
   @JoinColumn()
   readonly music: Music;
+  @Column()
   readonly views: number;
+  @Column()
   readonly ranking: number;
+  @Column()
   readonly rise: number;
+  @Column()
   readonly createdAt: Date;
 }

--- a/src/domain/chart/entity/chart-of-week.entity.ts
+++ b/src/domain/chart/entity/chart-of-week.entity.ts
@@ -1,0 +1,13 @@
+import { Music } from "src/domain/music/entity/music.entity";
+import { Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity()
+export class ChartOfWeek {
+  @PrimaryGeneratedColumn()
+  readonly id: number;
+  @ManyToOne(() => Music)
+  readonly music: Music;
+  readonly views: number;
+  readonly ranking: number;
+  readonly createdAt: Date;
+}

--- a/src/domain/chart/entity/chart-of-week.entity.ts
+++ b/src/domain/chart/entity/chart-of-week.entity.ts
@@ -1,11 +1,12 @@
 import { Music } from "src/domain/music/entity/music.entity";
-import { Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
 
 @Entity()
 export class ChartOfWeek {
   @PrimaryGeneratedColumn()
   readonly id: number;
-  @ManyToOne(() => Music)
+  @OneToOne(() => Music)
+  @JoinColumn()
   readonly music: Music;
   readonly views: number;
   readonly ranking: number;

--- a/src/domain/chart/entity/chart-of-week.entity.ts
+++ b/src/domain/chart/entity/chart-of-week.entity.ts
@@ -10,5 +10,6 @@ export class ChartOfWeek {
   readonly music: Music;
   readonly views: number;
   readonly ranking: number;
+  readonly rise: number;
   readonly createdAt: Date;
 }

--- a/src/domain/chart/entity/chart-of-year.entity.ts
+++ b/src/domain/chart/entity/chart-of-year.entity.ts
@@ -1,0 +1,19 @@
+import { Music } from "src/domain/music/entity/music.entity";
+import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+
+@Entity()
+export class ChartOfYear {
+  @PrimaryGeneratedColumn()
+  readonly id: number;
+  @OneToOne(() => Music)
+  @JoinColumn()
+  readonly music: Music;
+  @Column()
+  readonly views: number;
+  @Column()
+  readonly ranking: number;
+  @Column()
+  readonly rise: number;
+  @Column()
+  readonly createdAt: Date;
+}


### PR DESCRIPTION
## 개요
* 음악 차트를 저장하기 위한 엔티티를 추가합니다.
## 작업내용
* 주간 차트 엔티티 추가
* 일간 차트 엔티티 추가
* 시간 차트 엔티티 추가
* 월간 차트 엔티티 추가
* 연간 차트 엔티티 추가