### PR TITLE
🔀 :: 19 - 음악 스케줄러의 중복되는 부분 일부 제거

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,6 +22,7 @@ import { MusicInfoEachHourScheduler } from "./domain/music/util/music-info-each-
 import { MusicInfoEachMonthScheduler } from "./domain/music/util/music-info-each-month.scheduler";
 import { MusicInfoEachWeekScheduler } from "./domain/music/util/music-info-each-week.scheduler";
 import { MusicInfoEachYearScheduler } from "./domain/music/util/music-info-each-year.scheduler";
+import { MusicSchedulerUtil } from "./domain/music/util/music-scheduler.util";
 
 @Module({
   imports: [
@@ -78,7 +79,8 @@ import { MusicInfoEachYearScheduler } from "./domain/music/util/music-info-each-
     MusicInfoEachHourScheduler,
     MusicInfoEachMonthScheduler,
     MusicInfoEachWeekScheduler,
-    MusicInfoEachYearScheduler
+    MusicInfoEachYearScheduler,
+    MusicSchedulerUtil
   ]
 })
 export class AppModule {}

--- a/src/domain/chart/entity/base/base-chart.entity.ts
+++ b/src/domain/chart/entity/base/base-chart.entity.ts
@@ -1,0 +1,18 @@
+import { Music } from "src/domain/music/entity/music.entity";
+import { Column, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+
+export abstract class BaseChartEntity {
+  @PrimaryGeneratedColumn()
+  readonly id: number;
+  @OneToOne(() => Music)
+  @JoinColumn()
+  readonly music: Music;
+  @Column()
+  readonly views: number;
+  @Column()
+  readonly ranking: number;
+  @Column()
+  readonly rise: number;
+  @Column()
+  readonly createdAt: Date;
+}

--- a/src/domain/chart/entity/chart-of-day.entity.ts
+++ b/src/domain/chart/entity/chart-of-day.entity.ts
@@ -1,19 +1,5 @@
-import { Music } from "src/domain/music/entity/music.entity";
-import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Entity } from "typeorm";
+import { BaseChartEntity } from "./base/base-chart.entity";
 
 @Entity()
-export class ChartOfDay {
-  @PrimaryGeneratedColumn()
-  readonly id: number;
-  @OneToOne(() => Music)
-  @JoinColumn()
-  readonly music: Music;
-  @Column()
-  readonly views: number;
-  @Column()
-  readonly ranking: number;
-  @Column()
-  readonly rise: number;
-  @Column()
-  readonly createdAt: Date;
-}
+export class ChartOfDay extends BaseChartEntity {}

--- a/src/domain/chart/entity/chart-of-hour.entity.ts
+++ b/src/domain/chart/entity/chart-of-hour.entity.ts
@@ -1,19 +1,5 @@
-import { Music } from "src/domain/music/entity/music.entity";
-import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Entity } from "typeorm";
+import { BaseChartEntity } from "./base/base-chart.entity";
 
 @Entity()
-export class ChartOfHour {
-  @PrimaryGeneratedColumn()
-  readonly id: number;
-  @OneToOne(() => Music)
-  @JoinColumn()
-  readonly music: Music;
-  @Column()
-  readonly views: number;
-  @Column()
-  readonly ranking: number;
-  @Column()
-  readonly rise: number;
-  @Column()
-  readonly createdAt: Date;
-}
+export class ChartOfHour extends BaseChartEntity {}

--- a/src/domain/chart/entity/chart-of-month.entity.ts
+++ b/src/domain/chart/entity/chart-of-month.entity.ts
@@ -1,19 +1,5 @@
-import { Music } from "src/domain/music/entity/music.entity";
-import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Entity } from "typeorm";
+import { BaseChartEntity } from "./base/base-chart.entity";
 
 @Entity()
-export class ChartOfMonth {
-  @PrimaryGeneratedColumn()
-  readonly id: number;
-  @OneToOne(() => Music)
-  @JoinColumn()
-  readonly music: Music;
-  @Column()
-  readonly views: number;
-  @Column()
-  readonly ranking: number;
-  @Column()
-  readonly rise: number;
-  @Column()
-  readonly createdAt: Date;
-}
+export class ChartOfMonth extends BaseChartEntity {}

--- a/src/domain/chart/entity/chart-of-week.entity.ts
+++ b/src/domain/chart/entity/chart-of-week.entity.ts
@@ -1,19 +1,5 @@
-import { Music } from "src/domain/music/entity/music.entity";
-import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Entity } from "typeorm";
+import { BaseChartEntity } from "./base/base-chart.entity";
 
 @Entity()
-export class ChartOfWeek {
-  @PrimaryGeneratedColumn()
-  readonly id: number;
-  @OneToOne(() => Music)
-  @JoinColumn()
-  readonly music: Music;
-  @Column()
-  readonly views: number;
-  @Column()
-  readonly ranking: number;
-  @Column()
-  readonly rise: number;
-  @Column()
-  readonly createdAt: Date;
-}
+export class ChartOfWeek extends BaseChartEntity {}

--- a/src/domain/chart/entity/chart-of-year.entity.ts
+++ b/src/domain/chart/entity/chart-of-year.entity.ts
@@ -1,19 +1,5 @@
-import { Music } from "src/domain/music/entity/music.entity";
-import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Entity } from "typeorm";
+import { BaseChartEntity } from "./base/base-chart.entity";
 
 @Entity()
-export class ChartOfYear {
-  @PrimaryGeneratedColumn()
-  readonly id: number;
-  @OneToOne(() => Music)
-  @JoinColumn()
-  readonly music: Music;
-  @Column()
-  readonly views: number;
-  @Column()
-  readonly ranking: number;
-  @Column()
-  readonly rise: number;
-  @Column()
-  readonly createdAt: Date;
-}
+export class ChartOfYear extends BaseChartEntity {}

--- a/src/domain/music/entity/base/base-views.entity.ts
+++ b/src/domain/music/entity/base/base-views.entity.ts
@@ -13,4 +13,10 @@ export abstract class BaseViewsEntity {
 
   @CreateDateColumn()
   readonly createdAt: Date;
+
+  constructor(views: number, music: Music, createdDate: Date) {
+    this.views = views;
+    this.music = music;
+    this.createdAt = createdDate;
+  }
 }

--- a/src/domain/music/entity/base/base-views.entity.ts
+++ b/src/domain/music/entity/base/base-views.entity.ts
@@ -1,0 +1,16 @@
+import { Column, CreateDateColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Music } from "../music.entity";
+
+export abstract class BaseViewsEntity {
+  @PrimaryGeneratedColumn()
+  readonly id: number;
+
+  @Column()
+  readonly views: number;
+
+  @ManyToOne(() => Music)
+  readonly music: Music;
+
+  @CreateDateColumn()
+  readonly createdAt: Date;
+}

--- a/src/domain/music/entity/views-of-day.entity.ts
+++ b/src/domain/music/entity/views-of-day.entity.ts
@@ -1,17 +1,5 @@
-import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
-import { Music } from "./music.entity";
+import { Entity } from "typeorm";
+import { BaseViewsEntity } from "./base/base-views.entity";
 
 @Entity()
-export class ViewsOfDay {
-  @PrimaryGeneratedColumn()
-  id: number;
-
-  @Column()
-  views: number;
-
-  @ManyToOne(() => Music)
-  music: Music;
-
-  @CreateDateColumn()
-  readonly createdAt: Date;
-}
+export class ViewsOfDay extends BaseViewsEntity {}

--- a/src/domain/music/entity/views-of-hour.entity.ts
+++ b/src/domain/music/entity/views-of-hour.entity.ts
@@ -1,17 +1,5 @@
-import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
-import { Music } from "./music.entity";
+import { Entity } from "typeorm";
+import { BaseViewsEntity } from "./base/base-views.entity";
 
 @Entity()
-export class ViewsOfHour {
-  @PrimaryGeneratedColumn()
-  id: number;
-
-  @Column()
-  views: number;
-
-  @ManyToOne(() => Music)
-  music: Music;
-
-  @CreateDateColumn()
-  readonly createdAt: Date;
-}
+export class ViewsOfHour extends BaseViewsEntity {}

--- a/src/domain/music/entity/views-of-month.entity.ts
+++ b/src/domain/music/entity/views-of-month.entity.ts
@@ -1,17 +1,5 @@
-import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
-import { Music } from "./music.entity";
+import { Entity } from "typeorm";
+import { BaseViewsEntity } from "./base/base-views.entity";
 
 @Entity()
-export class ViewsOfMonth {
-  @PrimaryGeneratedColumn()
-  id: number;
-
-  @Column()
-  views: number;
-
-  @ManyToOne(() => Music)
-  music: Music;
-
-  @CreateDateColumn()
-  readonly createdAt: Date;
-}
+export class ViewsOfMonth extends BaseViewsEntity {}

--- a/src/domain/music/entity/views-of-week.entity.ts
+++ b/src/domain/music/entity/views-of-week.entity.ts
@@ -1,17 +1,5 @@
-import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
-import { Music } from "./music.entity";
+import { Entity } from "typeorm";
+import { BaseViewsEntity } from "./base/base-views.entity";
 
 @Entity()
-export class ViewsOfWeek {
-  @PrimaryGeneratedColumn()
-  id: number;
-
-  @Column()
-  views: number;
-
-  @ManyToOne(() => Music)
-  music: Music;
-
-  @CreateDateColumn()
-  readonly createdAt: Date;
-}
+export class ViewsOfWeek extends BaseViewsEntity {}

--- a/src/domain/music/entity/views-of-year.entity.ts
+++ b/src/domain/music/entity/views-of-year.entity.ts
@@ -1,17 +1,5 @@
-import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
-import { Music } from "./music.entity";
+import { Entity } from "typeorm";
+import { BaseViewsEntity } from "./base/base-views.entity";
 
 @Entity()
-export class ViewsOfYear {
-  @PrimaryGeneratedColumn()
-  id: number;
-
-  @Column()
-  views: number;
-
-  @ManyToOne(() => Music)
-  music: Music;
-
-  @CreateDateColumn()
-  readonly createdAt: Date;
-}
+export class ViewsOfYear extends BaseViewsEntity {}

--- a/src/domain/music/util/music-info-each-day.scheduler.ts
+++ b/src/domain/music/util/music-info-each-day.scheduler.ts
@@ -5,7 +5,7 @@ import { Repository } from "typeorm";
 import { Music } from "../entity/music.entity";
 import { YoutubeUtils } from "src/global/thridparty/youtube/youtube.util";
 import { ViewsOfDay } from "../entity/views-of-day.entity";
-import { ChartOfDay } from "src/domain/chart/entity/chart-of-day.entity";
+import { MusicSchedulerUtil } from "./music-scheduler.util";
 
 @Injectable()
 export class MusicInfoEachDayScheduler {
@@ -14,8 +14,7 @@ export class MusicInfoEachDayScheduler {
     private readonly musicRepository: Repository<Music>,
     @InjectRepository(ViewsOfDay)
     private readonly viewsOfDayRepository: Repository<ViewsOfDay>,
-    @InjectRepository(ChartOfDay)
-    private readonly chartOfDayRepository: Repository<ChartOfDay>,
+    private readonly musicSchdulerUtil: MusicSchedulerUtil,
     private readonly youtubeUtils: YoutubeUtils
   ) {}
 
@@ -43,26 +42,7 @@ export class MusicInfoEachDayScheduler {
     viewsOfDayList.sort((a: ViewsOfDay, b: ViewsOfDay) => b.views - a.views);
 
     viewsOfDayList.forEach(async (viewsOfDay, index) => {
-      const chartOfDay =
-        (await this.chartOfDayRepository.findOneBy({ music: viewsOfDay.music })) ??
-        (await this.chartOfDayRepository.save({
-          music: viewsOfDay.music,
-          views: viewsOfDay.views,
-          ranking: index + 1,
-          rise: 0,
-          createdAt: Date()
-        }));
-
-      this.chartOfDayRepository.update(
-        {
-          id: chartOfDay.id
-        },
-        {
-          views: viewsOfDay.views,
-          ranking: index + 1,
-          rise: chartOfDay.ranking - (index + 1)
-        }
-      );
+      await this.musicSchdulerUtil.saveChartEntityByViewsEntity(viewsOfDay, index);
     });
   }
 }

--- a/src/domain/music/util/music-info-each-day.scheduler.ts
+++ b/src/domain/music/util/music-info-each-day.scheduler.ts
@@ -32,11 +32,11 @@ export class MusicInfoEachDayScheduler {
       musicInfoList.map(async (musicInfo) => {
         const musicId = musicInfo.videoId;
         const music = musicList.find((music) => music.id === musicId);
-        return await this.viewsOfDayRepository.save({
-          views: musicInfo.viewCount,
-          music: music,
-          createdAt: Date()
-        });
+
+        if (music == undefined) throw new Error("this music is not found");
+
+        const viewsOfDay = new ViewsOfDay(musicInfo.viewCount, music!, new Date());
+        return await this.viewsOfDayRepository.save(viewsOfDay);
       })
     );
     viewsOfDayList.sort((a: ViewsOfDay, b: ViewsOfDay) => b.views - a.views);

--- a/src/domain/music/util/music-info-each-hour.shceduler.ts
+++ b/src/domain/music/util/music-info-each-hour.shceduler.ts
@@ -5,7 +5,7 @@ import { Repository } from "typeorm";
 import { Music } from "../entity/music.entity";
 import { YoutubeUtils } from "src/global/thridparty/youtube/youtube.util";
 import { ViewsOfHour } from "../entity/views-of-hour.entity";
-import { ChartOfHour } from "src/domain/chart/entity/chart-of-hour.entity";
+import { MusicSchedulerUtil } from "./music-scheduler.util";
 
 @Injectable()
 export class MusicInfoEachHourScheduler {
@@ -14,8 +14,7 @@ export class MusicInfoEachHourScheduler {
     private readonly musicRepository: Repository<Music>,
     @InjectRepository(ViewsOfHour)
     private readonly viewsOfHourRepository: Repository<ViewsOfHour>,
-    @InjectRepository(ChartOfHour)
-    private readonly chartOfHourRepository: Repository<ChartOfHour>,
+    private readonly musicSchedulerUtil: MusicSchedulerUtil,
     private readonly youtubeUtils: YoutubeUtils
   ) {}
 
@@ -43,26 +42,7 @@ export class MusicInfoEachHourScheduler {
     viewsOfHourList.sort((a: ViewsOfHour, b: ViewsOfHour) => b.views - a.views);
 
     viewsOfHourList.forEach(async (viewsOfHour, index) => {
-      const chartOfHour =
-        (await this.chartOfHourRepository.findOneBy({ music: viewsOfHour.music })) ??
-        (await this.chartOfHourRepository.save({
-          music: viewsOfHour.music,
-          views: viewsOfHour.views,
-          ranking: index + 1,
-          rise: 0,
-          createdAt: Date()
-        }));
-
-      this.chartOfHourRepository.update(
-        {
-          id: chartOfHour.id
-        },
-        {
-          views: viewsOfHour.views,
-          ranking: index + 1,
-          rise: chartOfHour.ranking - (index + 1)
-        }
-      );
+      await this.musicSchedulerUtil.saveChartEntityByViewsEntity(viewsOfHour, index);
     });
   }
 }

--- a/src/domain/music/util/music-info-each-hour.shceduler.ts
+++ b/src/domain/music/util/music-info-each-hour.shceduler.ts
@@ -32,11 +32,11 @@ export class MusicInfoEachHourScheduler {
       musicInfoList.map(async (musicInfo) => {
         const musicId = musicInfo.videoId;
         const music = musicList.find((music) => music.id === musicId);
-        return await this.viewsOfHourRepository.save({
-          views: musicInfo.viewCount,
-          music: music,
-          createdAt: Date()
-        });
+
+        if (music == undefined) throw new Error("this music is not found");
+
+        const viewsOfHour = new ViewsOfHour(musicInfo.viewCount, music!, new Date());
+        return await this.viewsOfHourRepository.save(viewsOfHour);
       })
     );
     viewsOfHourList.sort((a: ViewsOfHour, b: ViewsOfHour) => b.views - a.views);

--- a/src/domain/music/util/music-info-each-month.scheduler.ts
+++ b/src/domain/music/util/music-info-each-month.scheduler.ts
@@ -30,11 +30,11 @@ export class MusicInfoEachMonthScheduler {
       musicInfoList.map(async (musicInfo) => {
         const musicId = musicInfo.videoId;
         const music = musicList.find((music) => music.id === musicId);
-        return await this.viewsOfMonthRepository.save({
-          views: musicInfo.viewCount,
-          music: music,
-          createdAt: Date()
-        });
+
+        if (music == undefined) throw new Error("this music is not found");
+
+        const viewsOfMonth = new ViewsOfMonth(musicInfo.viewCount, music, new Date());
+        return await this.viewsOfMonthRepository.save(viewsOfMonth);
       })
     );
     viewsOfMonthList.sort((a: ViewsOfMonth, b: ViewsOfMonth) => b.views - a.views);

--- a/src/domain/music/util/music-info-each-month.scheduler.ts
+++ b/src/domain/music/util/music-info-each-month.scheduler.ts
@@ -1,10 +1,10 @@
 import { InjectRepository } from "@nestjs/typeorm";
 import { ViewsOfMonth } from "../entity/views-of-month.entity";
 import { Repository } from "typeorm";
-import { ChartOfMonth } from "src/domain/chart/entity/chart-of-month.entity";
 import { Cron, CronExpression } from "@nestjs/schedule";
 import { YoutubeUtils } from "src/global/thridparty/youtube/youtube.util";
 import { Music } from "../entity/music.entity";
+import { MusicSchedulerUtil } from "./music-scheduler.util";
 
 export class MusicInfoEachMonthScheduler {
   constructor(
@@ -13,8 +13,7 @@ export class MusicInfoEachMonthScheduler {
     private readonly musicRepository: Repository<Music>,
     @InjectRepository(ViewsOfMonth)
     private readonly viewsOfMonthRepository: Repository<ViewsOfMonth>,
-    @InjectRepository(ChartOfMonth)
-    private readonly chartOfMonthRepository: Repository<ChartOfMonth>
+    private readonly musicSchedulerUtil: MusicSchedulerUtil
   ) {}
 
   @Cron(CronExpression.EVERY_1ST_DAY_OF_MONTH_AT_MIDNIGHT)
@@ -41,26 +40,7 @@ export class MusicInfoEachMonthScheduler {
     viewsOfMonthList.sort((a: ViewsOfMonth, b: ViewsOfMonth) => b.views - a.views);
 
     viewsOfMonthList.forEach(async (viewsOfMonth, index) => {
-      const chartOfMonth =
-        (await this.chartOfMonthRepository.findOneBy({ music: viewsOfMonth.music })) ??
-        (await this.chartOfMonthRepository.save({
-          music: viewsOfMonth.music,
-          views: viewsOfMonth.views,
-          ranking: index + 1,
-          rise: 0,
-          createdAt: Date()
-        }));
-
-      this.chartOfMonthRepository.update(
-        {
-          id: chartOfMonth.id
-        },
-        {
-          views: viewsOfMonth.views,
-          ranking: index + 1,
-          rise: chartOfMonth.ranking - (index + 1)
-        }
-      );
+      await this.musicSchedulerUtil.saveChartEntityByViewsEntity(viewsOfMonth, index);
     });
   }
 }

--- a/src/domain/music/util/music-info-each-week.scheduler.ts
+++ b/src/domain/music/util/music-info-each-week.scheduler.ts
@@ -1,10 +1,10 @@
 import { Cron, CronExpression } from "@nestjs/schedule";
 import { InjectRepository } from "@nestjs/typeorm";
 import { ViewsOfWeek } from "../entity/views-of-week.entity";
-import { ChartOfWeek } from "src/domain/chart/entity/chart-of-week.entity";
 import { Repository } from "typeorm";
 import { YoutubeUtils } from "src/global/thridparty/youtube/youtube.util";
 import { Music } from "../entity/music.entity";
+import { MusicSchedulerUtil } from "./music-scheduler.util";
 
 export class MusicInfoEachWeekScheduler {
   constructor(
@@ -13,8 +13,7 @@ export class MusicInfoEachWeekScheduler {
     private readonly musicRepository: Repository<Music>,
     @InjectRepository(ViewsOfWeek)
     private readonly viewsOfWeekRepository: Repository<ViewsOfWeek>,
-    @InjectRepository(ChartOfWeek)
-    private readonly chartOfWeekRepository: Repository<ChartOfWeek>
+    private readonly musicSchedulerUtil: MusicSchedulerUtil
   ) {}
 
   @Cron(CronExpression.EVERY_WEEK)
@@ -41,26 +40,7 @@ export class MusicInfoEachWeekScheduler {
     viewsOfWeekList.sort((a: ViewsOfWeek, b: ViewsOfWeek) => b.views - a.views);
 
     viewsOfWeekList.forEach(async (viewsOfWeek, index) => {
-      const chartOfWeek =
-        (await this.chartOfWeekRepository.findOneBy({ music: viewsOfWeek.music })) ??
-        (await this.chartOfWeekRepository.save({
-          music: viewsOfWeek.music,
-          views: viewsOfWeek.views,
-          ranking: index + 1,
-          rise: 0,
-          createdAt: Date()
-        }));
-
-      this.chartOfWeekRepository.update(
-        {
-          id: chartOfWeek.id
-        },
-        {
-          views: chartOfWeek.views,
-          ranking: index + 1,
-          rise: chartOfWeek.ranking - (index + 1)
-        }
-      );
+      await this.musicSchedulerUtil.saveChartEntityByViewsEntity(viewsOfWeek, index);
     });
   }
 }

--- a/src/domain/music/util/music-info-each-week.scheduler.ts
+++ b/src/domain/music/util/music-info-each-week.scheduler.ts
@@ -30,11 +30,11 @@ export class MusicInfoEachWeekScheduler {
       musicInfoList.map(async (musicInfo) => {
         const musicId = musicInfo.videoId;
         const music = musicList.find((music) => music.id === musicId);
-        return await this.viewsOfWeekRepository.save({
-          views: musicInfo.viewCount,
-          music: music,
-          createdAt: Date()
-        });
+
+        if (music == undefined) throw new Error("this music is not found");
+
+        const viewsOfWeek = new ViewsOfWeek(musicInfo.viewCount, music, new Date());
+        return await this.viewsOfWeekRepository.save(viewsOfWeek);
       })
     );
     viewsOfWeekList.sort((a: ViewsOfWeek, b: ViewsOfWeek) => b.views - a.views);

--- a/src/domain/music/util/music-info-each-year.scheduler.ts
+++ b/src/domain/music/util/music-info-each-year.scheduler.ts
@@ -30,11 +30,11 @@ export class MusicInfoEachYearScheduler {
       musicInfoList.map(async (musicInfo) => {
         const musicId = musicInfo.videoId;
         const music = musicList.find((music) => music.id === musicId);
-        return await this.viewsOfYearRepository.save({
-          views: musicInfo.viewCount,
-          music: music,
-          createdAt: Date()
-        });
+
+        if (music == undefined) throw new Error("this music is not found");
+
+        const viewsOfYear = new ViewsOfYear(musicInfo.viewCount, music, new Date());
+        return await this.viewsOfYearRepository.save(viewsOfYear);
       })
     );
     viewsOfYearList.sort((a: ViewsOfYear, b: ViewsOfYear) => b.views - a.views);

--- a/src/domain/music/util/music-info-each-year.scheduler.ts
+++ b/src/domain/music/util/music-info-each-year.scheduler.ts
@@ -1,10 +1,10 @@
 import { Cron } from "@nestjs/schedule";
 import { ViewsOfYear } from "../entity/views-of-year.entity";
 import { InjectRepository } from "@nestjs/typeorm";
-import { ChartOfYear } from "src/domain/chart/entity/chart-of-year.entity";
 import { Repository } from "typeorm";
 import { YoutubeUtils } from "src/global/thridparty/youtube/youtube.util";
 import { Music } from "../entity/music.entity";
+import { MusicSchedulerUtil } from "./music-scheduler.util";
 
 export class MusicInfoEachYearScheduler {
   constructor(
@@ -13,8 +13,7 @@ export class MusicInfoEachYearScheduler {
     private readonly musicRepository: Repository<Music>,
     @InjectRepository(ViewsOfYear)
     private readonly viewsOfYearRepository: Repository<ViewsOfYear>,
-    @InjectRepository(ChartOfYear)
-    private readonly chartOfYearRepository: Repository<ChartOfYear>
+    private readonly musicSchedulerUtil: MusicSchedulerUtil
   ) {}
 
   @Cron("0 0 1 1 *")
@@ -41,26 +40,7 @@ export class MusicInfoEachYearScheduler {
     viewsOfYearList.sort((a: ViewsOfYear, b: ViewsOfYear) => b.views - a.views);
 
     viewsOfYearList.forEach(async (viewsOfYear, index) => {
-      const chartOfYear =
-        (await this.chartOfYearRepository.findOneBy({ music: viewsOfYear.music })) ??
-        (await this.chartOfYearRepository.save({
-          music: viewsOfYear.music,
-          views: viewsOfYear.views,
-          ranking: index + 1,
-          rise: 0,
-          createdAt: Date()
-        }));
-
-      this.chartOfYearRepository.update(
-        {
-          id: chartOfYear.id
-        },
-        {
-          views: chartOfYear.views,
-          ranking: index + 1,
-          rise: chartOfYear.ranking - (index + 1)
-        }
-      );
+      await this.musicSchedulerUtil.saveChartEntityByViewsEntity(viewsOfYear, index);
     });
   }
 }

--- a/src/domain/music/util/music-scheduler.util.ts
+++ b/src/domain/music/util/music-scheduler.util.ts
@@ -1,0 +1,70 @@
+import { Injectable } from "@nestjs/common";
+import { Repository } from "typeorm";
+import { InjectRepository } from "@nestjs/typeorm";
+import { ChartOfDay } from "src/domain/chart/entity/chart-of-day.entity";
+import { BaseViewsEntity } from "../entity/base/base-views.entity";
+import { ChartOfYear } from "src/domain/chart/entity/chart-of-year.entity";
+import { ChartOfHour } from "src/domain/chart/entity/chart-of-hour.entity";
+import { ChartOfMonth } from "src/domain/chart/entity/chart-of-month.entity";
+import { ChartOfWeek } from "src/domain/chart/entity/chart-of-week.entity";
+
+@Injectable()
+export class MusicSchedulerUtil {
+  constructor(
+    @InjectRepository(ChartOfDay)
+    private readonly chartOfDayRepository: Repository<ChartOfDay>,
+    @InjectRepository(ChartOfYear)
+    private readonly chartOfYearRepository: Repository<ChartOfYear>,
+    @InjectRepository(ChartOfHour)
+    private readonly chartOfHourRepository: Repository<ChartOfHour>,
+    @InjectRepository(ChartOfMonth)
+    private readonly chartOfMonthRepository: Repository<ChartOfMonth>,
+    @InjectRepository(ChartOfWeek)
+    private readonly chartOfWeekRepository: Repository<ChartOfWeek>
+  ) {}
+
+  async saveChartEntityByViewsEntity(viewsEntity: BaseViewsEntity, index: number) {
+    const repositoryMap: RepositoryMap = {
+      ViewsOfDay: this.chartOfDayRepository,
+      ViewsOfHour: this.chartOfHourRepository,
+      ViewsOfMonth: this.chartOfMonthRepository,
+      ViewsOfWeek: this.chartOfWeekRepository,
+      ViewsOfYear: this.chartOfYearRepository
+    };
+
+    const repository = repositoryMap[viewsEntity.constructor.name];
+
+    console.log(viewsEntity.constructor);
+    console.log(repositoryMap);
+    console.log(repository);
+
+    const chart =
+      (await repository.findOneBy({ music: viewsEntity.music })) ??
+      (await repository.save({
+        music: viewsEntity.music,
+        views: viewsEntity.views,
+        ranking: index + 1,
+        rise: 0,
+        createdAt: Date()
+      }));
+
+    await repository.update(
+      {
+        id: chart.id
+      },
+      {
+        views: chart.views,
+        ranking: index + 1,
+        rise: chart.ranking - (index + 1)
+      }
+    );
+  }
+}
+
+type RepositoryMap = {
+  ViewsOfDay: Repository<ChartOfDay>;
+  ViewsOfHour: Repository<ChartOfHour>;
+  ViewsOfMonth: Repository<ChartOfMonth>;
+  ViewsOfWeek: Repository<ChartOfWeek>;
+  ViewsOfYear: Repository<ChartOfYear>;
+};


### PR DESCRIPTION
## 개요
* 각각의 MusicInfoScheduler에서 중복되는 부분을 일부분 개선합니다.
## 작업내용
* BaseViewsEntity, BaseChartEntity 추가
* 각각의 views, chart 엔티티가 각 베이스 엔티티를 상속하도록 수정
* MusicSchedulerUtil 추가
* 각각의 스케줄러에서 차트 엔티티를 저장하는 로직을 musicSchedulerUtil을 사용하도록 수정
* BaseViewsEntity에 생성자 추가
  * 기존에 사용하던 방식은 Views 엔티티의 생성자가 호출되지 않아서 객체의 타입이 `Object`로 되어있어서 viewsEntity를 저장할때 생성자를 호출하도록 수정함