### PR TITLE
🔀 :: 32 - 스케줄러를 API 호출 방식으로 변경

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -23,6 +23,7 @@ import { MusicInfoEachMonthScheduler } from "./domain/music/util/music-info-each
 import { MusicInfoEachWeekScheduler } from "./domain/music/util/music-info-each-week.scheduler";
 import { MusicInfoEachYearScheduler } from "./domain/music/util/music-info-each-year.scheduler";
 import { MusicSchedulerUtil } from "./domain/music/util/music-scheduler.util";
+import { MusicSchedulersController } from "./domain/music/presentation/music-scheduler.controller";
 
 @Module({
   imports: [
@@ -80,7 +81,7 @@ import { MusicSchedulerUtil } from "./domain/music/util/music-scheduler.util";
     ]),
     ScheduleModule.forRoot()
   ],
-  controllers: [],
+  controllers: [MusicSchedulersController],
   providers: [
     ArtistGenerator,
     YoutubeUtils,

--- a/src/domain/music/presentation/music-scheduler.controller.ts
+++ b/src/domain/music/presentation/music-scheduler.controller.ts
@@ -1,9 +1,11 @@
-import { Controller, Post } from "@nestjs/common";
+import { Controller, Post, UseGuards } from "@nestjs/common";
 import { MusicInfoEachDayScheduler } from "../util/music-info-each-day.scheduler";
 import { MusicInfoEachHourScheduler } from "../util/music-info-each-hour.shceduler";
 import { MusicInfoEachMonthScheduler } from "../util/music-info-each-month.scheduler";
 import { MusicInfoEachWeekScheduler } from "../util/music-info-each-week.scheduler";
 import { MusicInfoEachYearScheduler } from "../util/music-info-each-year.scheduler";
+import { ApiKeyGuard } from "src/global/api/api-key.guard";
+import { ApiKey } from "src/global/api/api-key.decorator";
 
 @Controller("music-schedulers")
 export class MusicSchedulersController {
@@ -16,26 +18,36 @@ export class MusicSchedulersController {
   ) {}
 
   @Post("day")
+  @UseGuards(ApiKeyGuard)
+  @ApiKey(process.env.MUSIC_INFO_EACH_DAY_API_KEY)
   getMusicInfoEachDay() {
     this.musicInfoEachDayScheduler.getMusicInfoEachDay();
   }
 
   @Post("hour")
+  @UseGuards(ApiKeyGuard)
+  @ApiKey(process.env.MUSIC_INFO_EACH_HOUR_API_KEY)
   getMusicInfoEachHour() {
     this.musicInfoEachHourScheduler.getMusicInfoEachHour();
   }
 
   @Post("month")
+  @UseGuards(ApiKeyGuard)
+  @ApiKey(process.env.MUSIC_INFO_EACH_MONTH_API_KEY)
   getMusicInfoEachMonth() {
     this.musicInfoEachMonthScheduler.getMusicInfoEachMonth();
   }
 
   @Post("week")
+  @UseGuards(ApiKeyGuard)
+  @ApiKey(process.env.MUSIC_INFO_EACH_WEEK_API_KEY)
   getMusicInfoEachWeek() {
     this.musicInfoEachWeekScheduler.getMusicInfoEachWeek();
   }
 
   @Post("year")
+  @UseGuards(ApiKeyGuard)
+  @ApiKey(process.env.MUSIC_INFO_EACH_YEAR_API_KEY)
   getMusicInfoEachYear() {
     this.musicInfoEachYearScheduler.getMusicInfoEachYear();
   }

--- a/src/domain/music/presentation/music-scheduler.controller.ts
+++ b/src/domain/music/presentation/music-scheduler.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, Post } from "@nestjs/common";
+import { MusicInfoEachDayScheduler } from "../util/music-info-each-day.scheduler";
+import { MusicInfoEachHourScheduler } from "../util/music-info-each-hour.shceduler";
+import { MusicInfoEachMonthScheduler } from "../util/music-info-each-month.scheduler";
+import { MusicInfoEachWeekScheduler } from "../util/music-info-each-week.scheduler";
+import { MusicInfoEachYearScheduler } from "../util/music-info-each-year.scheduler";
+
+@Controller("music-schedulers")
+export class MusicSchedulersController {
+  constructor(
+    private readonly musicInfoEachDayScheduler: MusicInfoEachDayScheduler,
+    private readonly musicInfoEachHourScheduler: MusicInfoEachHourScheduler,
+    private readonly musicInfoEachMonthScheduler: MusicInfoEachMonthScheduler,
+    private readonly musicInfoEachWeekScheduler: MusicInfoEachWeekScheduler,
+    private readonly musicInfoEachYearScheduler: MusicInfoEachYearScheduler
+  ) {}
+
+  @Post("day")
+  getMusicInfoEachDay() {
+    this.musicInfoEachDayScheduler.getMusicInfoEachDay();
+  }
+
+  @Post("hour")
+  getMusicInfoEachHour() {
+    this.musicInfoEachHourScheduler.getMusicInfoEachHour();
+  }
+
+  @Post("month")
+  getMusicInfoEachMonth() {
+    this.musicInfoEachMonthScheduler.getMusicInfoEachMonth();
+  }
+
+  @Post("week")
+  getMusicInfoEachWeek() {
+    this.musicInfoEachWeekScheduler.getMusicInfoEachWeek();
+  }
+
+  @Post("year")
+  getMusicInfoEachYear() {
+    this.musicInfoEachYearScheduler.getMusicInfoEachYear();
+  }
+}

--- a/src/global/api/api-key.decorator.ts
+++ b/src/global/api/api-key.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from "@nestjs/common";
+
+export const API_KEY = "apiKey";
+export const ApiKey = (key: string | undefined) => SetMetadata(API_KEY, key);

--- a/src/global/api/api-key.guard.ts
+++ b/src/global/api/api-key.guard.ts
@@ -1,0 +1,24 @@
+import { Injectable, CanActivate, ExecutionContext, HttpException } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { API_KEY } from "./api-key.decorator";
+
+@Injectable()
+export class ApiKeyGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const apiKey = request.headers["api-key"];
+    const requiredApiKey = this.reflector.get<string>(API_KEY, context.getHandler());
+
+    if (!requiredApiKey || !this.validateApiKey(apiKey, requiredApiKey)) {
+      throw new HttpException("api key is not valid", 403);
+    }
+
+    return true;
+  }
+
+  validateApiKey(apiKey: string | undefined, requiredApiKey: string): boolean {
+    return apiKey !== undefined && apiKey === requiredApiKey;
+  }
+}

--- a/src/global/api/api-key.guard.ts
+++ b/src/global/api/api-key.guard.ts
@@ -8,17 +8,16 @@ export class ApiKeyGuard implements CanActivate {
 
   canActivate(context: ExecutionContext): boolean {
     const request = context.switchToHttp().getRequest();
-    const apiKey = request.headers["api-key"];
-    const requiredApiKey = this.reflector.get<string>(API_KEY, context.getHandler());
-
-    if (!requiredApiKey || !this.validateApiKey(apiKey, requiredApiKey)) {
+    const apiKey = request.headers["api-key"] as string;
+    const comparedApiKey = this.reflector.get<string>(API_KEY, context.getHandler());
+    if (!comparedApiKey || !this.validateApiKey(apiKey, comparedApiKey)) {
       throw new HttpException("api key is not valid", 403);
     }
 
     return true;
   }
 
-  validateApiKey(apiKey: string | undefined, requiredApiKey: string): boolean {
-    return apiKey !== undefined && apiKey === requiredApiKey;
+  validateApiKey(apiKey: string, requiredApiKey: string): boolean {
+    return apiKey === requiredApiKey;
   }
 }


### PR DESCRIPTION
## 개요
* 서버리스 환경에서 스케줄러가 동작하게 하기 위해 스케줄링 작업 API를 만들고, 외부 cron을 이용해서 해당 API를 실행하는 방법으로 변경합니다.
## 작업내용
* MusicSchedulersController 추가
* 검증할 API key를 세팅하는 데코레이터 추가
* ApiKeyGuard 추가
* 컨트롤러에 ApiKeyGuard 적용