### PR TITLE
🔀 :: [#34] - 영상 정보가 조회되지 않는 버그 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3397,12 +3397,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -4914,9 +4914,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -7129,9 +7129,9 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "node_modules/mysql2": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.9.7.tgz",
-      "integrity": "sha512-KnJT8vYRcNAZv73uf9zpXqNbvBG7DJrs+1nACsjZP1HMJ1TgXEy8wnNilXAn/5i57JizXKtrUtwDB7HxT9DDpw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.10.0.tgz",
+      "integrity": "sha512-qx0mfWYt1DpTPkw8mAcHW/OwqqyNqBLBHvY5IjN8+icIYTjt6znrgYJ+gxqNNRpVknb5Wc/gcCM4XjbCR0j5tw==",
       "dependencies": {
         "denque": "^2.1.0",
         "generate-function": "^2.3.1",
@@ -12495,12 +12495,12 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "browserslist": {
@@ -13594,9 +13594,9 @@
       }
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
@@ -15261,9 +15261,9 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "mysql2": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.9.7.tgz",
-      "integrity": "sha512-KnJT8vYRcNAZv73uf9zpXqNbvBG7DJrs+1nACsjZP1HMJ1TgXEy8wnNilXAn/5i57JizXKtrUtwDB7HxT9DDpw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.10.0.tgz",
+      "integrity": "sha512-qx0mfWYt1DpTPkw8mAcHW/OwqqyNqBLBHvY5IjN8+icIYTjt6znrgYJ+gxqNNRpVknb5Wc/gcCM4XjbCR0j5tw==",
       "requires": {
         "denque": "^2.1.0",
         "generate-function": "^2.3.1",

--- a/src/domain/music/util/music-info-each-hour.shceduler.ts
+++ b/src/domain/music/util/music-info-each-hour.shceduler.ts
@@ -35,6 +35,9 @@ export class MusicInfoEachHourScheduler {
 
         if (music == undefined) throw new Error("this music is not found");
 
+        music.views = musicInfo.viewCount;
+        this.musicRepository.update(musicId, { views: musicInfo.viewCount });
+
         const viewsOfHour = new ViewsOfHour(musicInfo.viewCount, music!, new Date());
         return await this.viewsOfHourRepository.save(viewsOfHour);
       })

--- a/src/domain/music/util/music-scheduler.util.ts
+++ b/src/domain/music/util/music-scheduler.util.ts
@@ -34,10 +34,6 @@ export class MusicSchedulerUtil {
 
     const repository = repositoryMap[viewsEntity.constructor.name];
 
-    console.log(viewsEntity.constructor);
-    console.log(repositoryMap);
-    console.log(repository);
-
     const chart =
       (await repository.findOneBy({ music: viewsEntity.music })) ??
       (await repository.save({

--- a/src/global/util/array.util.ts
+++ b/src/global/util/array.util.ts
@@ -1,0 +1,10 @@
+export class ArrayUtil {
+  static async chunkArray<T>(array: T[], chunkSize: number): Promise<T[][]> {
+    const result: T[][] = [];
+    for (let i = 0; i < array.length; i += chunkSize) {
+      const chunk = array.slice(i, i + chunkSize);
+      result.push(chunk);
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
## 개요
* youtube api를 사용해서 영상정보를 조회할때 한번에 최대 50개까지만 가능하지만, 전체 음악수가 50개를 넘어가면서 에러 발생
## 작업내용
* ArrayUtil 객체 추가
  * 배열을 사이즈에 맞게 분리시키는 메서드 추가
* 영상 정보 조회시 한번에 50개의 영상 정보를 가져오도록 수정
* 한시간마다 노래 정보 갱신시에 노래 엔티티의 조회수를 갱신하는 로직 추가
  * 모든 스케줄러 로직에 추가하려 했는데, 시간마다 갱신되면, 굳이 다른 스케줄러에는 필요하지 않을 것 같아서, MusicInfoEachHourScheduler에만 추가
* MusicSchedulerUtil에 존재하던 console.log 제거