### PR TITLE
🔀 :: [#36] - 컨트롤러및 스케줄러 로직을 비동기 처리하도록 수정

### DIFF
--- a/src/domain/music/presentation/music-scheduler.controller.ts
+++ b/src/domain/music/presentation/music-scheduler.controller.ts
@@ -20,35 +20,35 @@ export class MusicSchedulersController {
   @Post("day")
   @UseGuards(ApiKeyGuard)
   @ApiKey(process.env.MUSIC_INFO_EACH_DAY_API_KEY)
-  getMusicInfoEachDay() {
-    this.musicInfoEachDayScheduler.getMusicInfoEachDay();
+  async getMusicInfoEachDay() {
+    await this.musicInfoEachDayScheduler.getMusicInfoEachDay();
   }
 
   @Post("hour")
   @UseGuards(ApiKeyGuard)
   @ApiKey(process.env.MUSIC_INFO_EACH_HOUR_API_KEY)
-  getMusicInfoEachHour() {
-    this.musicInfoEachHourScheduler.getMusicInfoEachHour();
+  async getMusicInfoEachHour() {
+    await this.musicInfoEachHourScheduler.getMusicInfoEachHour();
   }
 
   @Post("month")
   @UseGuards(ApiKeyGuard)
   @ApiKey(process.env.MUSIC_INFO_EACH_MONTH_API_KEY)
-  getMusicInfoEachMonth() {
-    this.musicInfoEachMonthScheduler.getMusicInfoEachMonth();
+  async getMusicInfoEachMonth() {
+    await this.musicInfoEachMonthScheduler.getMusicInfoEachMonth();
   }
 
   @Post("week")
   @UseGuards(ApiKeyGuard)
   @ApiKey(process.env.MUSIC_INFO_EACH_WEEK_API_KEY)
-  getMusicInfoEachWeek() {
-    this.musicInfoEachWeekScheduler.getMusicInfoEachWeek();
+  async getMusicInfoEachWeek() {
+    await this.musicInfoEachWeekScheduler.getMusicInfoEachWeek();
   }
 
   @Post("year")
   @UseGuards(ApiKeyGuard)
   @ApiKey(process.env.MUSIC_INFO_EACH_YEAR_API_KEY)
-  getMusicInfoEachYear() {
-    this.musicInfoEachYearScheduler.getMusicInfoEachYear();
+  async getMusicInfoEachYear() {
+    await this.musicInfoEachYearScheduler.getMusicInfoEachYear();
   }
 }

--- a/src/domain/music/util/music-info-each-day.scheduler.ts
+++ b/src/domain/music/util/music-info-each-day.scheduler.ts
@@ -14,7 +14,7 @@ export class MusicInfoEachDayScheduler {
     private readonly musicRepository: Repository<Music>,
     @InjectRepository(ViewsOfDay)
     private readonly viewsOfDayRepository: Repository<ViewsOfDay>,
-    private readonly musicSchdulerUtil: MusicSchedulerUtil,
+    private readonly musicSchedulerUtil: MusicSchedulerUtil,
     private readonly youtubeUtils: YoutubeUtils
   ) {}
 
@@ -41,8 +41,10 @@ export class MusicInfoEachDayScheduler {
     );
     viewsOfDayList.sort((a: ViewsOfDay, b: ViewsOfDay) => b.views - a.views);
 
-    viewsOfDayList.forEach(async (viewsOfDay, index) => {
-      await this.musicSchdulerUtil.saveChartEntityByViewsEntity(viewsOfDay, index);
-    });
+    await Promise.all(
+      viewsOfDayList.map(async (viewsOfDay, index) => {
+        await this.musicSchedulerUtil.saveChartEntityByViewsEntity(viewsOfDay, index);
+      })
+    );
   }
 }

--- a/src/domain/music/util/music-info-each-hour.shceduler.ts
+++ b/src/domain/music/util/music-info-each-hour.shceduler.ts
@@ -44,8 +44,10 @@ export class MusicInfoEachHourScheduler {
     );
     viewsOfHourList.sort((a: ViewsOfHour, b: ViewsOfHour) => b.views - a.views);
 
-    viewsOfHourList.forEach(async (viewsOfHour, index) => {
-      await this.musicSchedulerUtil.saveChartEntityByViewsEntity(viewsOfHour, index);
-    });
+    await Promise.all(
+      viewsOfHourList.map(async (viewsOfHour, index) => {
+        await this.musicSchedulerUtil.saveChartEntityByViewsEntity(viewsOfHour, index);
+      })
+    );
   }
 }

--- a/src/domain/music/util/music-info-each-month.scheduler.ts
+++ b/src/domain/music/util/music-info-each-month.scheduler.ts
@@ -39,8 +39,10 @@ export class MusicInfoEachMonthScheduler {
     );
     viewsOfMonthList.sort((a: ViewsOfMonth, b: ViewsOfMonth) => b.views - a.views);
 
-    viewsOfMonthList.forEach(async (viewsOfMonth, index) => {
-      await this.musicSchedulerUtil.saveChartEntityByViewsEntity(viewsOfMonth, index);
-    });
+    await Promise.all(
+      viewsOfMonthList.map(async (viewsOfMonth, index) => {
+        await this.musicSchedulerUtil.saveChartEntityByViewsEntity(viewsOfMonth, index);
+      })
+    );
   }
 }

--- a/src/domain/music/util/music-info-each-week.scheduler.ts
+++ b/src/domain/music/util/music-info-each-week.scheduler.ts
@@ -39,8 +39,10 @@ export class MusicInfoEachWeekScheduler {
     );
     viewsOfWeekList.sort((a: ViewsOfWeek, b: ViewsOfWeek) => b.views - a.views);
 
-    viewsOfWeekList.forEach(async (viewsOfWeek, index) => {
-      await this.musicSchedulerUtil.saveChartEntityByViewsEntity(viewsOfWeek, index);
-    });
+    await Promise.all(
+      viewsOfWeekList.map(async (viewsOfWeek, index) => {
+        await this.musicSchedulerUtil.saveChartEntityByViewsEntity(viewsOfWeek, index);
+      })
+    );
   }
 }

--- a/src/domain/music/util/music-info-each-year.scheduler.ts
+++ b/src/domain/music/util/music-info-each-year.scheduler.ts
@@ -39,8 +39,10 @@ export class MusicInfoEachYearScheduler {
     );
     viewsOfYearList.sort((a: ViewsOfYear, b: ViewsOfYear) => b.views - a.views);
 
-    viewsOfYearList.forEach(async (viewsOfYear, index) => {
-      await this.musicSchedulerUtil.saveChartEntityByViewsEntity(viewsOfYear, index);
-    });
+    await Promise.all(
+      viewsOfYearList.map(async (viewsOfYear, index) => {
+        await this.musicSchedulerUtil.saveChartEntityByViewsEntity(viewsOfYear, index);
+      })
+    );
   }
 }


### PR DESCRIPTION
## 개요
* 지금 vercel에서 동작하는 방식이 요청이 들어오면 서버를 활성화하고, 응답하면 바로 비활성화를 하기 때문에 전부 동기처리를 하도록 수정해서 무시되는 로직이 없도록 수정했습니다
## 작업내용
* 컨트롤러에 async/await 문법 적용
* 스케줄러 로직에서 forEach를 사용하던 부분을 Promise.all을 사용해서 동기 처리