### PR TITLE
🔀 :: [#38] - 음악 조회 API 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -24,6 +24,8 @@ import { MusicInfoEachWeekScheduler } from "./domain/music/util/music-info-each-
 import { MusicInfoEachYearScheduler } from "./domain/music/util/music-info-each-year.scheduler";
 import { MusicSchedulerUtil } from "./domain/music/util/music-scheduler.util";
 import { MusicSchedulersController } from "./domain/music/presentation/music-scheduler.controller";
+import { MusicService } from "./domain/music/service/music.service";
+import { MusicController } from "./domain/music/presentation/music.controller";
 
 @Module({
   imports: [
@@ -81,7 +83,7 @@ import { MusicSchedulersController } from "./domain/music/presentation/music-sch
     ]),
     ScheduleModule.forRoot()
   ],
-  controllers: [MusicSchedulersController],
+  controllers: [MusicSchedulersController, MusicController],
   providers: [
     ArtistGenerator,
     YoutubeUtils,
@@ -90,7 +92,8 @@ import { MusicSchedulersController } from "./domain/music/presentation/music-sch
     MusicInfoEachMonthScheduler,
     MusicInfoEachWeekScheduler,
     MusicInfoEachYearScheduler,
-    MusicSchedulerUtil
+    MusicSchedulerUtil,
+    MusicService
   ]
 })
 export class AppModule {}

--- a/src/domain/music/data/response/music-list.response.ts
+++ b/src/domain/music/data/response/music-list.response.ts
@@ -1,0 +1,5 @@
+import { MusicResponse } from "./music.response";
+
+export class MusicListResponse {
+  constructor(readonly list: MusicResponse[]) {}
+}

--- a/src/domain/music/data/response/music.response.ts
+++ b/src/domain/music/data/response/music.response.ts
@@ -1,0 +1,11 @@
+export class MusicResponse {
+  constructor(
+    readonly id: string,
+    readonly name: string,
+    readonly youtubeId: string,
+    readonly views: number,
+    readonly uploadedDate: Date,
+    readonly TJKaraokeCode: number,
+    readonly KYKaraokeCode: number
+  ) {}
+}

--- a/src/domain/music/data/response/music.response.ts
+++ b/src/domain/music/data/response/music.response.ts
@@ -1,3 +1,5 @@
+import { ParticipantInfo } from "src/domain/participant/data/response/participant-info.response";
+
 export class MusicResponse {
   constructor(
     readonly id: string,
@@ -6,6 +8,7 @@ export class MusicResponse {
     readonly views: number,
     readonly uploadedDate: Date,
     readonly TJKaraokeCode: number,
-    readonly KYKaraokeCode: number
+    readonly KYKaraokeCode: number,
+    readonly participantInfos: ParticipantInfo[]
   ) {}
 }

--- a/src/domain/music/enum/sort-by.enum.ts
+++ b/src/domain/music/enum/sort-by.enum.ts
@@ -1,0 +1,5 @@
+export enum SortBy {
+  UPLOAD = "UPLOAD",
+  OLDER = "OLDER",
+  VIEWS = "VIEWS"
+}

--- a/src/domain/music/presentation/music.controller.ts
+++ b/src/domain/music/presentation/music.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, ParseEnumPipe, Query } from "@nestjs/common";
+import { MusicService } from "../service/music.service";
+import { MusicListResponse } from "../data/response/music-list.response";
+import { SortBy } from "../enum/sort-by.enum";
+
+@Controller("musics")
+export class MusicController {
+  constructor(private readonly musicService: MusicService) {}
+
+  @Get()
+  async getMusics(
+    @Query("sortBy", new ParseEnumPipe(SortBy)) sortBy: SortBy
+  ): Promise<MusicListResponse> {
+    return await this.musicService.getMusic(sortBy);
+  }
+}

--- a/src/domain/music/service/music.service.ts
+++ b/src/domain/music/service/music.service.ts
@@ -1,0 +1,59 @@
+import { HttpException, Injectable } from "@nestjs/common";
+import { Repository } from "typeorm";
+import { Music } from "../entity/music.entity";
+import { InjectRepository } from "@nestjs/typeorm";
+import { MusicResponse } from "../data/response/music.response";
+import { MusicListResponse } from "../data/response/music-list.response";
+
+@Injectable()
+export class MusicService {
+  constructor(
+    @InjectRepository(Music)
+    private readonly musicRepository: Repository<Music>
+  ) {}
+
+  async getMusic(sortBy: string): Promise<MusicListResponse> {
+    let musicList: Music[];
+    switch (sortBy) {
+      case "UPLOAD":
+        musicList = await this.musicRepository.find({
+          order: {
+            uploadedDate: "DESC"
+          }
+        });
+        break;
+      case "OLDER":
+        musicList = await this.musicRepository.find({
+          order: {
+            uploadedDate: "ASC"
+          }
+        });
+        break;
+      case "VIEWS":
+        musicList = await this.musicRepository.find({
+          order: {
+            views: "DESC"
+          }
+        });
+        break;
+      default:
+        throw new HttpException("sorting filter is not valid", 400);
+    }
+
+    const musicResponseList = await Promise.all(
+      musicList.map(async (music) => {
+        return new MusicResponse(
+          music.id,
+          music.name,
+          music.youtubeId,
+          music.views,
+          music.uploadedDate,
+          music.TJKaraokeCode,
+          music.KYKaraokeCode
+        );
+      })
+    );
+
+    return new MusicListResponse(musicResponseList);
+  }
+}

--- a/src/domain/music/service/music.service.ts
+++ b/src/domain/music/service/music.service.ts
@@ -4,6 +4,7 @@ import { Music } from "../entity/music.entity";
 import { InjectRepository } from "@nestjs/typeorm";
 import { MusicResponse } from "../data/response/music.response";
 import { MusicListResponse } from "../data/response/music-list.response";
+import { SortBy } from "../enum/sort-by.enum";
 
 @Injectable()
 export class MusicService {
@@ -12,24 +13,24 @@ export class MusicService {
     private readonly musicRepository: Repository<Music>
   ) {}
 
-  async getMusic(sortBy: string): Promise<MusicListResponse> {
+  async getMusic(sortBy: SortBy): Promise<MusicListResponse> {
     let musicList: Music[];
     switch (sortBy) {
-      case "UPLOAD":
+      case SortBy.UPLOAD:
         musicList = await this.musicRepository.find({
           order: {
             uploadedDate: "DESC"
           }
         });
         break;
-      case "OLDER":
+      case SortBy.OLDER:
         musicList = await this.musicRepository.find({
           order: {
             uploadedDate: "ASC"
           }
         });
         break;
-      case "VIEWS":
+      case SortBy.VIEWS:
         musicList = await this.musicRepository.find({
           order: {
             views: "DESC"

--- a/src/domain/participant/data/response/participant-info.response.ts
+++ b/src/domain/participant/data/response/participant-info.response.ts
@@ -1,0 +1,6 @@
+export class ParticipantInfo {
+  constructor(
+    readonly artistId: number,
+    readonly artistName: string
+  ) {}
+}


### PR DESCRIPTION
## 개요
* 음악 조회 API를 추가합니다.
## 작업내용
* MusicResponse, MusicListResponse 추가
* 정렬 enum 타입 추가
* MusicService에 정렬 타입에 맞게 음악을 반환하는 로직 추가
* 음악 조회 엔드포인트 추가
* AppModule에 MusicController, MusicService 추가