### PR TITLE
🔀 :: [#41] - 차트 엔티티가 제대로 저장되지 않는 버그

### DIFF
--- a/src/domain/music/util/music-scheduler.util.ts
+++ b/src/domain/music/util/music-scheduler.util.ts
@@ -49,7 +49,7 @@ export class MusicSchedulerUtil {
         id: chart.id
       },
       {
-        views: chart.views,
+        views: viewsEntity.views,
         ranking: index + 1,
         rise: chart.ranking - (index + 1)
       }


### PR DESCRIPTION
## 개요
* 차트엔티티를 갱신할때 기존 chart의 view를 받아와서 랭킹이랑 조회수가 일치하지 않고, 조회수 갱신이 되지 않는 버그 발생
## 작업내용
* 조회수를 viewEntity에서 받아오도록 수정