### PR TITLE
🔀 :: [#40] - 음악 차트 조회 API 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -26,6 +26,7 @@ import { MusicSchedulerUtil } from "./domain/music/util/music-scheduler.util";
 import { MusicSchedulersController } from "./domain/music/presentation/music-scheduler.controller";
 import { MusicService } from "./domain/music/service/music.service";
 import { MusicController } from "./domain/music/presentation/music.controller";
+import { GetChartUtil } from "./domain/chart/util/get-chart.util";
 
 @Module({
   imports: [
@@ -93,7 +94,8 @@ import { MusicController } from "./domain/music/presentation/music.controller";
     MusicInfoEachWeekScheduler,
     MusicInfoEachYearScheduler,
     MusicSchedulerUtil,
-    MusicService
+    MusicService,
+    GetChartUtil
   ]
 })
 export class AppModule {}

--- a/src/domain/chart/util/get-chart.util.ts
+++ b/src/domain/chart/util/get-chart.util.ts
@@ -62,28 +62,26 @@ export class GetChartUtil {
 
     const chartMap = new Map<string, MusicChartResponse>();
 
-    await Promise.all(
-      rawResult.map(async (result) => {
-        const participantInfo = new ParticipantInfo(result.artist_id, result.artist_name);
-        if (chartMap.has(result.music_id)) {
-          chartMap.get(result.music_id)?.participantInfos.push(participantInfo);
-        } else {
-          const musicChartResponse = new MusicChartResponse(
-            result.music_id,
-            result.music_name,
-            result.music_youtubeId,
-            result.music_views,
-            result.uploadedDate,
-            result.music_TJKaraokeCode,
-            result.music_KYKaraokeCode,
-            result.rise,
-            result.ranking,
-            [participantInfo]
-          );
-          chartMap.set(result.music_id, musicChartResponse);
-        }
-      })
-    );
+    rawResult.map((result) => {
+      const participantInfo = new ParticipantInfo(result.artist_id, result.artist_name);
+      if (chartMap.has(result.music_id)) {
+        chartMap.get(result.music_id)?.participantInfos.push(participantInfo);
+      } else {
+        const musicChartResponse = new MusicChartResponse(
+          result.music_id,
+          result.music_name,
+          result.music_youtubeId,
+          result.music_views,
+          result.uploadedDate,
+          result.music_TJKaraokeCode,
+          result.music_KYKaraokeCode,
+          result.rise,
+          result.ranking,
+          [participantInfo]
+        );
+        chartMap.set(result.music_id, musicChartResponse);
+      }
+    });
 
     return Array.from(chartMap.values());
   }

--- a/src/domain/chart/util/get-chart.util.ts
+++ b/src/domain/chart/util/get-chart.util.ts
@@ -6,7 +6,7 @@ import { Repository } from "typeorm";
 import { ChartOfHour } from "../entity/chart-of-hour.entity";
 import { ChartOfMonth } from "../entity/chart-of-month.entity";
 import { ChartOfWeek } from "../entity/chart-of-week.entity";
-import { BaseChartEntity } from "../entity/base/base-chart.entity";
+// import { BaseChartEntity } from "../entity/base/base-chart.entity";
 import { ChartBy } from "src/domain/music/enum/chart-by.enum";
 
 @Injectable()
@@ -24,8 +24,14 @@ export class GetChartUtil {
     private readonly chartOfWeekRepository: Repository<ChartOfWeek>
   ) {}
 
-  async getChart(chartBy: ChartBy): Promise<BaseChartEntity[]> {
-    const repositoryMap: { [key: string]: Repository<BaseChartEntity> } = {
+  async getChart(
+    chartBy: ChartBy
+  ): Promise<ChartOfDay[] | ChartOfHour[] | ChartOfYear[] | ChartOfMonth[] | ChartOfWeek[]> {
+    const repositoryMap: {
+      [key: string]: Repository<
+        ChartOfDay | ChartOfHour | ChartOfYear | ChartOfMonth | ChartOfWeek
+      >;
+    } = {
       HOUR: this.chartOfDayRepository,
       DAY: this.chartOfHourRepository,
       WEEK: this.chartOfMonthRepository,
@@ -34,7 +40,7 @@ export class GetChartUtil {
     };
 
     const chartRepository = repositoryMap[chartBy];
-    const chartList = await chartRepository.find();
+    const chartList = await chartRepository.find({ relations: ["music"] });
 
     return chartList;
   }

--- a/src/domain/chart/util/get-chart.util.ts
+++ b/src/domain/chart/util/get-chart.util.ts
@@ -6,8 +6,11 @@ import { Repository } from "typeorm";
 import { ChartOfHour } from "../entity/chart-of-hour.entity";
 import { ChartOfMonth } from "../entity/chart-of-month.entity";
 import { ChartOfWeek } from "../entity/chart-of-week.entity";
-// import { BaseChartEntity } from "../entity/base/base-chart.entity";
 import { ChartBy } from "src/domain/music/enum/chart-by.enum";
+import { Participant } from "src/domain/participant/entity/participant.entity";
+import { Artist } from "src/domain/artist/entity/artist.entity";
+import { MusicChartResponse } from "src/domain/music/data/response/music-chart.response";
+import { ParticipantInfo } from "src/domain/participant/data/response/participant-info.response";
 
 @Injectable()
 export class GetChartUtil {
@@ -24,9 +27,7 @@ export class GetChartUtil {
     private readonly chartOfWeekRepository: Repository<ChartOfWeek>
   ) {}
 
-  async getChart(
-    chartBy: ChartBy
-  ): Promise<ChartOfDay[] | ChartOfHour[] | ChartOfYear[] | ChartOfMonth[] | ChartOfWeek[]> {
+  async getChart(chartBy: ChartBy): Promise<MusicChartResponse[]> {
     const repositoryMap: {
       [key: string]: Repository<
         ChartOfDay | ChartOfHour | ChartOfYear | ChartOfMonth | ChartOfWeek
@@ -40,11 +41,42 @@ export class GetChartUtil {
     };
 
     const chartRepository = repositoryMap[chartBy];
-    const chartList = await chartRepository.find({
-      relations: ["music"],
-      order: { views: "DESC" }
-    });
+    const rawResult = await chartRepository
+      .createQueryBuilder("chart")
+      .leftJoinAndSelect("chart.music", "music")
+      .leftJoin(Participant, "participant", "participant.musicId = music.id")
+      .leftJoin(Artist, "artist", "participant.artistId = artist.id")
+      .select(["chart", "music", "participant.id", "artist.id", "artist.name"])
+      .orderBy("music.views", "DESC")
+      .getRawMany();
 
-    return chartList;
+    console.log(rawResult);
+
+    const chartMap = new Map<string, MusicChartResponse>();
+
+    await Promise.all(
+      rawResult.map(async (result) => {
+        const participantInfo = new ParticipantInfo(result.artist_id, result.artist_name);
+        if (chartMap.has(result.music_id)) {
+          chartMap.get(result.music_id)?.participantInfos.push(participantInfo);
+        } else {
+          const musicChartResponse = new MusicChartResponse(
+            result.music_id,
+            result.music_name,
+            result.music_youtubeId,
+            result.music_views,
+            result.uploadedDate,
+            result.TJKaraokeCode,
+            result.KYKaraokeCode,
+            result.chart_rise,
+            result.chart_ranking,
+            [participantInfo]
+          );
+          chartMap.set(result.music_id, musicChartResponse);
+        }
+      })
+    );
+
+    return Array.from(chartMap.values());
   }
 }

--- a/src/domain/chart/util/get-chart.util.ts
+++ b/src/domain/chart/util/get-chart.util.ts
@@ -40,7 +40,10 @@ export class GetChartUtil {
     };
 
     const chartRepository = repositoryMap[chartBy];
-    const chartList = await chartRepository.find({ relations: ["music"] });
+    const chartList = await chartRepository.find({
+      relations: ["music"],
+      order: { views: "DESC" }
+    });
 
     return chartList;
   }

--- a/src/domain/chart/util/get-chart.util.ts
+++ b/src/domain/chart/util/get-chart.util.ts
@@ -39,14 +39,22 @@ export class GetChartUtil {
       MONTH: this.chartOfWeekRepository,
       YEAR: this.chartOfYearRepository
     };
+    const chartTypeMap = {
+      [ChartBy.HOUR]: "chart_of_hour",
+      [ChartBy.DAY]: "chart_of_day",
+      [ChartBy.WEEK]: "chart_of_week",
+      [ChartBy.MONTH]: "chart_of_month",
+      [ChartBy.YEAR]: "chart_of_year"
+    };
+    const chartType = chartTypeMap[chartBy];
 
     const chartRepository = repositoryMap[chartBy];
     const rawResult = await chartRepository
-      .createQueryBuilder("chart")
-      .leftJoinAndSelect("chart.music", "music")
+      .createQueryBuilder(chartType)
+      .leftJoinAndSelect(`${chartType}.music`, "music")
       .leftJoin(Participant, "participant", "participant.musicId = music.id")
       .leftJoin(Artist, "artist", "participant.artistId = artist.id")
-      .select(["chart", "music", "participant.id", "artist.id", "artist.name"])
+      .select([`${chartType}.*`, "music", "participant.id", "artist.id", "artist.name"])
       .orderBy("music.views", "DESC")
       .getRawMany();
 
@@ -66,10 +74,10 @@ export class GetChartUtil {
             result.music_youtubeId,
             result.music_views,
             result.uploadedDate,
-            result.TJKaraokeCode,
-            result.KYKaraokeCode,
-            result.chart_rise,
-            result.chart_ranking,
+            result.music_TJKaraokeCode,
+            result.music_KYKaraokeCode,
+            result.rise,
+            result.ranking,
             [participantInfo]
           );
           chartMap.set(result.music_id, musicChartResponse);

--- a/src/domain/chart/util/get-chart.util.ts
+++ b/src/domain/chart/util/get-chart.util.ts
@@ -1,0 +1,41 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { ChartOfDay } from "../entity/chart-of-day.entity";
+import { ChartOfYear } from "../entity/chart-of-year.entity";
+import { Repository } from "typeorm";
+import { ChartOfHour } from "../entity/chart-of-hour.entity";
+import { ChartOfMonth } from "../entity/chart-of-month.entity";
+import { ChartOfWeek } from "../entity/chart-of-week.entity";
+import { BaseChartEntity } from "../entity/base/base-chart.entity";
+import { ChartBy } from "src/domain/music/enum/chart-by.enum";
+
+@Injectable()
+export class GetChartUtil {
+  constructor(
+    @InjectRepository(ChartOfDay)
+    private readonly chartOfDayRepository: Repository<ChartOfDay>,
+    @InjectRepository(ChartOfYear)
+    private readonly chartOfYearRepository: Repository<ChartOfYear>,
+    @InjectRepository(ChartOfHour)
+    private readonly chartOfHourRepository: Repository<ChartOfHour>,
+    @InjectRepository(ChartOfMonth)
+    private readonly chartOfMonthRepository: Repository<ChartOfMonth>,
+    @InjectRepository(ChartOfWeek)
+    private readonly chartOfWeekRepository: Repository<ChartOfWeek>
+  ) {}
+
+  async getChart(chartBy: ChartBy): Promise<BaseChartEntity[]> {
+    const repositoryMap: { [key: string]: Repository<BaseChartEntity> } = {
+      HOUR: this.chartOfDayRepository,
+      DAY: this.chartOfHourRepository,
+      WEEK: this.chartOfMonthRepository,
+      MONTH: this.chartOfWeekRepository,
+      YEAR: this.chartOfYearRepository
+    };
+
+    const chartRepository = repositoryMap[chartBy];
+    const chartList = await chartRepository.find();
+
+    return chartList;
+  }
+}

--- a/src/domain/music/data/response/music-chart-list.response.ts
+++ b/src/domain/music/data/response/music-chart-list.response.ts
@@ -1,0 +1,5 @@
+import { MusicChartResponse } from "./music-chart.response";
+
+export class MusicChartListResponse {
+  constructor(readonly list: MusicChartResponse[]) {}
+}

--- a/src/domain/music/data/response/music-chart.response.ts
+++ b/src/domain/music/data/response/music-chart.response.ts
@@ -10,6 +10,7 @@ export class MusicChartResponse {
     readonly TJKaraokeCode: number | null,
     readonly KYKaraokeCode: number | null,
     readonly rise: number,
+    readonly ranking: number,
     readonly participantInfos: ParticipantInfo[]
   ) {}
 }

--- a/src/domain/music/data/response/music-chart.response.ts
+++ b/src/domain/music/data/response/music-chart.response.ts
@@ -7,8 +7,8 @@ export class MusicChartResponse {
     readonly youtubeId: string,
     readonly views: number,
     readonly uploadedDate: Date,
-    readonly TJKaraokeCode: number,
-    readonly KYKaraokeCode: number,
+    readonly TJKaraokeCode: number | null,
+    readonly KYKaraokeCode: number | null,
     readonly rise: number,
     readonly participantInfos: ParticipantInfo[]
   ) {}

--- a/src/domain/music/data/response/music-chart.response.ts
+++ b/src/domain/music/data/response/music-chart.response.ts
@@ -1,0 +1,15 @@
+import { ParticipantInfo } from "src/domain/participant/data/response/participant-info.response";
+
+export class MusicChartResponse {
+  constructor(
+    readonly id: string,
+    readonly name: string,
+    readonly youtubeId: string,
+    readonly views: number,
+    readonly uploadedDate: Date,
+    readonly TJKaraokeCode: number,
+    readonly KYKaraokeCode: number,
+    readonly rise: number,
+    readonly participantInfos: ParticipantInfo[]
+  ) {}
+}

--- a/src/domain/music/data/response/music.response.ts
+++ b/src/domain/music/data/response/music.response.ts
@@ -7,8 +7,8 @@ export class MusicResponse {
     readonly youtubeId: string,
     readonly views: number,
     readonly uploadedDate: Date,
-    readonly TJKaraokeCode: number,
-    readonly KYKaraokeCode: number,
+    readonly TJKaraokeCode: number | null,
+    readonly KYKaraokeCode: number | null,
     readonly participantInfos: ParticipantInfo[]
   ) {}
 }

--- a/src/domain/music/entity/music.entity.ts
+++ b/src/domain/music/entity/music.entity.ts
@@ -17,9 +17,9 @@ export class Music {
   @Column()
   uploadedDate: Date;
 
-  @Column()
-  TJKaraokeCode: number;
+  @Column({ type: "integer", nullable: true })
+  TJKaraokeCode: number | null;
 
-  @Column()
-  KYKaraokeCode: number;
+  @Column({ type: "integer", nullable: true })
+  KYKaraokeCode: number | null;
 }

--- a/src/domain/music/enum/chart-by.enum.ts
+++ b/src/domain/music/enum/chart-by.enum.ts
@@ -1,0 +1,8 @@
+export enum ChartBy {
+  HOUR = "HOUR",
+  DAY = "DAY",
+  WEEK = "WEEK",
+  MONTH = "MONTH",
+  YEAR = "YEAR",
+  STACKED = "STACKED"
+}

--- a/src/domain/music/enum/chart-by.enum.ts
+++ b/src/domain/music/enum/chart-by.enum.ts
@@ -4,5 +4,5 @@ export enum ChartBy {
   WEEK = "WEEK",
   MONTH = "MONTH",
   YEAR = "YEAR",
-  STACKED = "STACKED"
+  TOTAL = "TOTAL"
 }

--- a/src/domain/music/presentation/music.controller.ts
+++ b/src/domain/music/presentation/music.controller.ts
@@ -2,6 +2,8 @@ import { Controller, Get, ParseEnumPipe, Query } from "@nestjs/common";
 import { MusicService } from "../service/music.service";
 import { MusicListResponse } from "../data/response/music-list.response";
 import { SortBy } from "../enum/sort-by.enum";
+import { ChartBy } from "../enum/chart-by.enum";
+import { MusicChartListResponse } from "../data/response/music-chart-list.response";
 
 @Controller("musics")
 export class MusicController {
@@ -12,5 +14,12 @@ export class MusicController {
     @Query("sortBy", new ParseEnumPipe(SortBy)) sortBy: SortBy
   ): Promise<MusicListResponse> {
     return await this.musicService.getMusic(sortBy);
+  }
+
+  @Get("chart")
+  async getMusicChart(
+    @Query("chartBy", new ParseEnumPipe(ChartBy)) chartBy: ChartBy
+  ): Promise<MusicChartListResponse> {
+    return await this.musicService.getMusicChart(chartBy);
   }
 }

--- a/src/domain/music/service/music.service.ts
+++ b/src/domain/music/service/music.service.ts
@@ -62,33 +62,62 @@ export class MusicService {
   }
 
   async getMusicChart(chartBy: ChartBy): Promise<MusicChartListResponse> {
-    const chartList = await this.getChartUtil.getChart(chartBy);
-    const musicChartResponseList = await Promise.all(
-      chartList.map(async (chart) => {
-        const music = chart.music;
-        const pariticipantList = await this.participantRepository.find({
-          where: { music },
-          relations: ["artist"]
-        });
-        const participantInfoList = await Promise.all(
-          pariticipantList.map(async (participant) => {
-            return new ParticipantInfo(participant.artist.id, participant.artist.name);
-          })
-        );
-        return new MusicChartResponse(
-          music.id,
-          music.name,
-          music.youtubeId,
-          music.views,
-          music.uploadedDate,
-          music.TJKaraokeCode,
-          music.KYKaraokeCode,
-          chart.rise,
-          participantInfoList
-        );
-      })
-    );
-    return new MusicChartListResponse(musicChartResponseList);
+    if (chartBy == ChartBy.TOTAL) {
+      const musicList = await this.musicRepository.find({ order: { views: "DESC" } });
+      const musicChartResponseList = await Promise.all(
+        musicList.map(async (music) => {
+          const pariticipantList = await this.participantRepository.find({
+            where: { music },
+            relations: ["artist"]
+          });
+          const participantInfoList = await Promise.all(
+            pariticipantList.map(async (participant) => {
+              return new ParticipantInfo(participant.artist.id, participant.artist.name);
+            })
+          );
+          return new MusicChartResponse(
+            music.id,
+            music.name,
+            music.youtubeId,
+            music.views,
+            music.uploadedDate,
+            music.TJKaraokeCode,
+            music.KYKaraokeCode,
+            0,
+            participantInfoList
+          );
+        })
+      );
+      return new MusicChartListResponse(musicChartResponseList);
+    } else {
+      const chartList = await this.getChartUtil.getChart(chartBy);
+      const musicChartResponseList = await Promise.all(
+        chartList.map(async (chart) => {
+          const music = chart.music;
+          const pariticipantList = await this.participantRepository.find({
+            where: { music },
+            relations: ["artist"]
+          });
+          const participantInfoList = await Promise.all(
+            pariticipantList.map(async (participant) => {
+              return new ParticipantInfo(participant.artist.id, participant.artist.name);
+            })
+          );
+          return new MusicChartResponse(
+            music.id,
+            music.name,
+            music.youtubeId,
+            music.views,
+            music.uploadedDate,
+            music.TJKaraokeCode,
+            music.KYKaraokeCode,
+            chart.rise,
+            participantInfoList
+          );
+        })
+      );
+      return new MusicChartListResponse(musicChartResponseList);
+    }
   }
 
   private async transformParticipantsToMusicResponse(

--- a/src/domain/music/service/music.service.ts
+++ b/src/domain/music/service/music.service.ts
@@ -62,38 +62,37 @@ export class MusicService {
   }
 
   async getMusicChart(chartBy: ChartBy): Promise<MusicChartListResponse> {
-    if (chartBy == ChartBy.TOTAL) {
-      const musicList = await this.musicRepository.find({ order: { views: "DESC" } });
-      const musicChartResponseList = await Promise.all(
-        musicList.map(async (music, index) => {
-          const pariticipantList = await this.participantRepository.find({
-            where: { music },
-            relations: ["artist"]
-          });
-          const participantInfoList = await Promise.all(
-            pariticipantList.map(async (participant) => {
-              return new ParticipantInfo(participant.artist.id, participant.artist.name);
-            })
-          );
-          return new MusicChartResponse(
-            music.id,
-            music.name,
-            music.youtubeId,
-            music.views,
-            music.uploadedDate,
-            music.TJKaraokeCode,
-            music.KYKaraokeCode,
-            0,
-            index + 1,
-            participantInfoList
-          );
-        })
-      );
-      return new MusicChartListResponse(musicChartResponseList);
-    } else {
+    if (chartBy != ChartBy.TOTAL) {
       const chartList = await this.getChartUtil.getChart(chartBy);
       return new MusicChartListResponse(chartList);
     }
+    const musicList = await this.musicRepository.find({ order: { views: "DESC" } });
+    const musicChartResponseList = await Promise.all(
+      musicList.map(async (music, index) => {
+        const pariticipantList = await this.participantRepository.find({
+          where: { music },
+          relations: ["artist"]
+        });
+        const participantInfoList = await Promise.all(
+          pariticipantList.map(async (participant) => {
+            return new ParticipantInfo(participant.artist.id, participant.artist.name);
+          })
+        );
+        return new MusicChartResponse(
+          music.id,
+          music.name,
+          music.youtubeId,
+          music.views,
+          music.uploadedDate,
+          music.TJKaraokeCode,
+          music.KYKaraokeCode,
+          0,
+          index + 1,
+          participantInfoList
+        );
+      })
+    );
+    return new MusicChartListResponse(musicChartResponseList);
   }
 
   private async transformParticipantsToMusicResponse(

--- a/src/domain/music/service/music.service.ts
+++ b/src/domain/music/service/music.service.ts
@@ -73,11 +73,9 @@ export class MusicService {
           where: { music },
           relations: ["artist"]
         });
-        const participantInfoList = await Promise.all(
-          pariticipantList.map(async (participant) => {
-            return new ParticipantInfo(participant.artist.id, participant.artist.name);
-          })
-        );
+        const participantInfoList = pariticipantList.map((participant) => {
+          return new ParticipantInfo(participant.artist.id, participant.artist.name);
+        });
         return new MusicChartResponse(
           music.id,
           music.name,

--- a/src/domain/music/service/music.service.ts
+++ b/src/domain/music/service/music.service.ts
@@ -65,7 +65,7 @@ export class MusicService {
     if (chartBy == ChartBy.TOTAL) {
       const musicList = await this.musicRepository.find({ order: { views: "DESC" } });
       const musicChartResponseList = await Promise.all(
-        musicList.map(async (music) => {
+        musicList.map(async (music, index) => {
           const pariticipantList = await this.participantRepository.find({
             where: { music },
             relations: ["artist"]
@@ -84,6 +84,7 @@ export class MusicService {
             music.TJKaraokeCode,
             music.KYKaraokeCode,
             0,
+            index + 1,
             participantInfoList
           );
         })
@@ -91,32 +92,7 @@ export class MusicService {
       return new MusicChartListResponse(musicChartResponseList);
     } else {
       const chartList = await this.getChartUtil.getChart(chartBy);
-      const musicChartResponseList = await Promise.all(
-        chartList.map(async (chart) => {
-          const music = chart.music;
-          const pariticipantList = await this.participantRepository.find({
-            where: { music },
-            relations: ["artist"]
-          });
-          const participantInfoList = await Promise.all(
-            pariticipantList.map(async (participant) => {
-              return new ParticipantInfo(participant.artist.id, participant.artist.name);
-            })
-          );
-          return new MusicChartResponse(
-            music.id,
-            music.name,
-            music.youtubeId,
-            music.views,
-            music.uploadedDate,
-            music.TJKaraokeCode,
-            music.KYKaraokeCode,
-            chart.rise,
-            participantInfoList
-          );
-        })
-      );
-      return new MusicChartListResponse(musicChartResponseList);
+      return new MusicChartListResponse(chartList);
     }
   }
 

--- a/src/domain/music/service/music.service.ts
+++ b/src/domain/music/service/music.service.ts
@@ -62,7 +62,7 @@ export class MusicService {
   }
 
   async getMusicChart(chartBy: ChartBy): Promise<MusicChartListResponse> {
-    const chartList = (await this.getChartUtil.getChart(chartBy)).sort((a, b) => b.views - a.views);
+    const chartList = await this.getChartUtil.getChart(chartBy);
     const musicChartResponseList = await Promise.all(
       chartList.map(async (chart) => {
         const music = chart.music;


### PR DESCRIPTION
## 개요
* 음악 차트를 조회하는 API를 추가합니다.
## 작업내용
* ChartBy enum 타입 추가
* GetChartUtil 추가
* Appmodule에 GetChartUtil 추가
* GetChartUtil에서 연관관계도 같이 가져오도록 수정
* 음악 차트 응답 객체 추가
* 음악 차트 조회 로직 추가
* 차트 조회 엔드포인트 추가