### PR TITLE
🔀 :: [#45] - 연관관계 양방향으로 수정

### DIFF
--- a/src/domain/artist/entity/artist.entity.ts
+++ b/src/domain/artist/entity/artist.entity.ts
@@ -1,4 +1,5 @@
-import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from "typeorm";
+import { Participant } from "src/domain/participant/entity/participant.entity";
+import { BaseEntity, Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
 
 @Entity()
 export class Artist extends BaseEntity {
@@ -7,4 +8,7 @@ export class Artist extends BaseEntity {
 
   @Column()
   name: string;
+
+  @OneToMany(() => Participant, (participant) => participant.artist)
+  participants: Participant[];
 }

--- a/src/domain/music/entity/music.entity.ts
+++ b/src/domain/music/entity/music.entity.ts
@@ -1,4 +1,5 @@
-import { Column, Entity, PrimaryColumn } from "typeorm";
+import { Participant } from "src/domain/participant/entity/participant.entity";
+import { Column, Entity, OneToMany, PrimaryColumn } from "typeorm";
 
 @Entity()
 export class Music {
@@ -22,4 +23,7 @@ export class Music {
 
   @Column({ type: "integer", nullable: true })
   KYKaraokeCode: number | null;
+
+  @OneToMany(() => Participant, (participant) => participant.music)
+  participants: Participant[];
 }

--- a/src/domain/participant/entity/participant.entity.ts
+++ b/src/domain/participant/entity/participant.entity.ts
@@ -7,9 +7,9 @@ export class Participant {
   @PrimaryGeneratedColumn()
   readonly id: number;
 
-  @ManyToOne(() => Artist)
+  @ManyToOne(() => Artist, (artist) => artist.participants)
   readonly artist: Artist;
 
-  @ManyToOne(() => Music)
+  @ManyToOne(() => Music, (music) => music.participants)
   readonly music: Music;
 }


### PR DESCRIPTION
## 개요
* 엔티티의 연관관계를 양방향으로 수정합니다.
## 작업내용
* artist 엔티티에 participants 필드 추가
* music 엔티티에 participants 필드 추가
## 기타
* chart 엔티티와 music엔티티는 OneToOne이라 단방향으로 해도 될듯합니다.
* music 엔티티랑 views 엔티티는 Views엔티티를 조회할일이 없을것 같아서 추가하지 않았습니다
  * 만약 필요할 경우가 있다고 생각된다면, 코멘트 날려주세용