### PR TITLE
🔀 :: [#44] - 음악 조회 API에서 join을 활용하도록 수정

### DIFF
--- a/src/domain/chart/util/get-chart.util.ts
+++ b/src/domain/chart/util/get-chart.util.ts
@@ -54,11 +54,9 @@ export class GetChartUtil {
       .leftJoinAndSelect(`${chartType}.music`, "music")
       .leftJoin(Participant, "participant", "participant.musicId = music.id")
       .leftJoin(Artist, "artist", "participant.artistId = artist.id")
-      .select([`${chartType}.*`, "music", "participant.id", "artist.id", "artist.name"])
+      .select([`${chartType}.*`, "music", "artist.id", "artist.name"])
       .orderBy("music.views", "DESC")
       .getRawMany();
-
-    console.log(rawResult);
 
     const chartMap = new Map<string, MusicChartResponse>();
 

--- a/src/domain/chart/util/get-chart.util.ts
+++ b/src/domain/chart/util/get-chart.util.ts
@@ -43,7 +43,7 @@ export class GetChartUtil {
     const chartRepository = repositoryMap[chartBy] as Repository<T>;
     const rawResult = await chartRepository.find({
       relations: ["music", "music.participants", "music.participants.artist"],
-      order: { ranking: "DESC" } as FindOptionsOrder<T>
+      order: { ranking: "ASC" } as FindOptionsOrder<T>
     });
 
     const chartResponseList = rawResult.map((result) => {

--- a/src/domain/chart/util/get-chart.util.ts
+++ b/src/domain/chart/util/get-chart.util.ts
@@ -2,13 +2,11 @@ import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { ChartOfDay } from "../entity/chart-of-day.entity";
 import { ChartOfYear } from "../entity/chart-of-year.entity";
-import { Repository } from "typeorm";
+import { FindOptionsOrder, Repository } from "typeorm";
 import { ChartOfHour } from "../entity/chart-of-hour.entity";
 import { ChartOfMonth } from "../entity/chart-of-month.entity";
 import { ChartOfWeek } from "../entity/chart-of-week.entity";
 import { ChartBy } from "src/domain/music/enum/chart-by.enum";
-import { Participant } from "src/domain/participant/entity/participant.entity";
-import { Artist } from "src/domain/artist/entity/artist.entity";
 import { MusicChartResponse } from "src/domain/music/data/response/music-chart.response";
 import { ParticipantInfo } from "src/domain/participant/data/response/participant-info.response";
 
@@ -27,7 +25,9 @@ export class GetChartUtil {
     private readonly chartOfWeekRepository: Repository<ChartOfWeek>
   ) {}
 
-  async getChart(chartBy: ChartBy): Promise<MusicChartResponse[]> {
+  async getChart<T extends ChartOfDay | ChartOfHour | ChartOfYear | ChartOfMonth | ChartOfWeek>(
+    chartBy: ChartBy
+  ): Promise<MusicChartResponse[]> {
     const repositoryMap: {
       [key: string]: Repository<
         ChartOfDay | ChartOfHour | ChartOfYear | ChartOfMonth | ChartOfWeek
@@ -39,48 +39,32 @@ export class GetChartUtil {
       MONTH: this.chartOfWeekRepository,
       YEAR: this.chartOfYearRepository
     };
-    const chartTypeMap = {
-      [ChartBy.HOUR]: "chart_of_hour",
-      [ChartBy.DAY]: "chart_of_day",
-      [ChartBy.WEEK]: "chart_of_week",
-      [ChartBy.MONTH]: "chart_of_month",
-      [ChartBy.YEAR]: "chart_of_year"
-    };
-    const chartType = chartTypeMap[chartBy];
 
-    const chartRepository = repositoryMap[chartBy];
-    const rawResult = await chartRepository
-      .createQueryBuilder(chartType)
-      .leftJoinAndSelect(`${chartType}.music`, "music")
-      .leftJoin(Participant, "participant", "participant.musicId = music.id")
-      .leftJoin(Artist, "artist", "participant.artistId = artist.id")
-      .select([`${chartType}.*`, "music", "artist.id", "artist.name"])
-      .orderBy("music.views", "DESC")
-      .getRawMany();
-
-    const chartMap = new Map<string, MusicChartResponse>();
-
-    rawResult.map((result) => {
-      const participantInfo = new ParticipantInfo(result.artist_id, result.artist_name);
-      if (chartMap.has(result.music_id)) {
-        chartMap.get(result.music_id)?.participantInfos.push(participantInfo);
-      } else {
-        const musicChartResponse = new MusicChartResponse(
-          result.music_id,
-          result.music_name,
-          result.music_youtubeId,
-          result.music_views,
-          result.uploadedDate,
-          result.music_TJKaraokeCode,
-          result.music_KYKaraokeCode,
-          result.rise,
-          result.ranking,
-          [participantInfo]
-        );
-        chartMap.set(result.music_id, musicChartResponse);
-      }
+    const chartRepository = repositoryMap[chartBy] as Repository<T>;
+    const rawResult = await chartRepository.find({
+      relations: ["music", "music.participants", "music.participants.artist"],
+      order: { ranking: "DESC" } as FindOptionsOrder<T>
     });
 
-    return Array.from(chartMap.values());
+    const chartResponseList = rawResult.map((result) => {
+      const participantInfos = result.music.participants.map((participant) => {
+        return new ParticipantInfo(participant.artist.id, participant.artist.name);
+      });
+      const musicChartResponse = new MusicChartResponse(
+        result.music.id,
+        result.music.name,
+        result.music.youtubeId,
+        result.music.views,
+        result.music.uploadedDate,
+        result.music.TJKaraokeCode,
+        result.music.KYKaraokeCode,
+        result.rise,
+        result.ranking,
+        participantInfos
+      );
+      return musicChartResponse;
+    });
+
+    return chartResponseList;
   }
 }

--- a/src/domain/music/service/music.service.ts
+++ b/src/domain/music/service/music.service.ts
@@ -23,40 +23,45 @@ export class MusicService {
   ) {}
 
   async getMusic(sortBy: SortBy): Promise<MusicListResponse> {
-    let pariticipantList: Participant[];
+    let musicList: Music[];
     switch (sortBy) {
       case SortBy.UPLOAD:
-        pariticipantList = await this.participantRepository
-          .createQueryBuilder("participant")
-          .leftJoinAndSelect("participant.music", "music")
-          .leftJoinAndSelect("participant.artist", "artist")
-          .select(["participant", "music", "artist"])
-          .orderBy("music.uploadedDate", "DESC")
-          .getMany();
+        musicList = await this.musicRepository.find({
+          relations: ["participants", "participants.artist"],
+          order: { uploadedDate: "DESC" }
+        });
         break;
       case SortBy.OLDER:
-        pariticipantList = await this.participantRepository
-          .createQueryBuilder("participant")
-          .leftJoinAndSelect("participant.music", "music")
-          .leftJoinAndSelect("participant.artist", "artist")
-          .select(["participant", "music", "artist"])
-          .orderBy("music.uploadedDate", "ASC")
-          .getMany();
+        musicList = await this.musicRepository.find({
+          relations: ["participants", "participants.artist"],
+          order: { uploadedDate: "ASC" }
+        });
         break;
       case SortBy.VIEWS:
-        pariticipantList = await this.participantRepository
-          .createQueryBuilder("participant")
-          .leftJoinAndSelect("participant.music", "music")
-          .leftJoinAndSelect("participant.artist", "artist")
-          .select(["participant", "music", "artist"])
-          .orderBy("music.views", "DESC")
-          .getMany();
+        musicList = await this.musicRepository.find({
+          relations: ["participants", "participants.artist"],
+          order: { views: "DESC" }
+        });
         break;
       default:
         throw new HttpException("sorting filter is not valid", 400);
     }
 
-    const musicResponseList = await this.transformParticipantsToMusicResponse(pariticipantList);
+    const musicResponseList = musicList.map((music) => {
+      const participantInfos = music.participants.map((pariticipant) => {
+        return new ParticipantInfo(pariticipant.artist.id, pariticipant.artist.name);
+      });
+      return new MusicResponse(
+        music.id,
+        music.name,
+        music.youtubeId,
+        music.views,
+        music.uploadedDate,
+        music.TJKaraokeCode,
+        music.KYKaraokeCode,
+        participantInfos
+      );
+    });
 
     return new MusicListResponse(musicResponseList);
   }


### PR DESCRIPTION
## 개요
* 음악 조회 API에서 join을 활용하도록 수정합니다.
## 작업내용
* 노래 조회 로직에 join 적용
* TOTAL 차트 조회 로직 수정
* 차트 조회 로직 수정