### PR TITLE
🔀 :: [#48] - 아티스트 조회 API 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -27,6 +27,8 @@ import { MusicSchedulersController } from "./domain/music/presentation/music-sch
 import { MusicService } from "./domain/music/service/music.service";
 import { MusicController } from "./domain/music/presentation/music.controller";
 import { GetChartUtil } from "./domain/chart/util/get-chart.util";
+import { ArtistService } from "./domain/artist/service/artist.service";
+import { ArtistController } from "./domain/artist/presentation/artist.controller";
 
 @Module({
   imports: [
@@ -84,7 +86,7 @@ import { GetChartUtil } from "./domain/chart/util/get-chart.util";
     ]),
     ScheduleModule.forRoot()
   ],
-  controllers: [MusicSchedulersController, MusicController],
+  controllers: [MusicSchedulersController, MusicController, ArtistController],
   providers: [
     ArtistGenerator,
     YoutubeUtils,
@@ -95,7 +97,8 @@ import { GetChartUtil } from "./domain/chart/util/get-chart.util";
     MusicInfoEachYearScheduler,
     MusicSchedulerUtil,
     MusicService,
-    GetChartUtil
+    GetChartUtil,
+    ArtistService
   ]
 })
 export class AppModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -29,6 +29,7 @@ import { MusicController } from "./domain/music/presentation/music.controller";
 import { GetChartUtil } from "./domain/chart/util/get-chart.util";
 import { ArtistService } from "./domain/artist/service/artist.service";
 import { ArtistController } from "./domain/artist/presentation/artist.controller";
+import { ChannelUrl } from "./domain/artist/entity/channel-url.entity";
 
 @Module({
   imports: [
@@ -56,7 +57,8 @@ import { ArtistController } from "./domain/artist/presentation/artist.controller
         ViewsOfDay,
         ViewsOfHour,
         ViewsOfMonth,
-        ViewsOfYear
+        ViewsOfYear,
+        ChannelUrl
       ],
       synchronize: true,
       ssl: process.env.DATABASE_SSL === "true",

--- a/src/domain/artist/data/response/artist-list.response.ts
+++ b/src/domain/artist/data/response/artist-list.response.ts
@@ -1,0 +1,5 @@
+import { AritstResponse } from "./artist.response";
+
+export class AritstListResponse {
+  constructor(readonly list: AritstResponse[]) {}
+}

--- a/src/domain/artist/data/response/artist.response.ts
+++ b/src/domain/artist/data/response/artist.response.ts
@@ -1,0 +1,9 @@
+export class AritstResponse {
+  constructor(
+    readonly id: number,
+    readonly name: string,
+    readonly chzzkUrl: string,
+    readonly youtubeUrl: string,
+    readonly youtubeMusicUrl: string
+  ) {}
+}

--- a/src/domain/artist/data/response/artist.response.ts
+++ b/src/domain/artist/data/response/artist.response.ts
@@ -4,6 +4,6 @@ export class AritstResponse {
     readonly name: string,
     readonly chzzkUrl: string,
     readonly youtubeUrl: string,
-    readonly youtubeMusicUrl: string
+    readonly youtubeMusicUrl: string | null
   ) {}
 }

--- a/src/domain/artist/data/response/artist.response.ts
+++ b/src/domain/artist/data/response/artist.response.ts
@@ -2,8 +2,6 @@ export class AritstResponse {
   constructor(
     readonly id: number,
     readonly name: string,
-    readonly chzzkUrl: string,
-    readonly youtubeUrl: string,
-    readonly youtubeMusicUrl: string | null
+    readonly urls: { name: string; url: string }[]
   ) {}
 }

--- a/src/domain/artist/entity/artist.entity.ts
+++ b/src/domain/artist/entity/artist.entity.ts
@@ -9,6 +9,15 @@ export class Artist extends BaseEntity {
   @Column()
   name: string;
 
+  @Column()
+  chzzkUrl: string;
+
+  @Column()
+  youtubeUrl: string;
+
+  @Column()
+  youtueMusicUrl: string | null;
+
   @OneToMany(() => Participant, (participant) => participant.artist)
   participants: Participant[];
 }

--- a/src/domain/artist/entity/artist.entity.ts
+++ b/src/domain/artist/entity/artist.entity.ts
@@ -1,5 +1,6 @@
 import { Participant } from "src/domain/participant/entity/participant.entity";
 import { BaseEntity, Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+import { ChannelUrl } from "./channel-url.entity";
 
 @Entity()
 export class Artist extends BaseEntity {
@@ -9,15 +10,9 @@ export class Artist extends BaseEntity {
   @Column()
   name: string;
 
-  @Column()
-  chzzkUrl: string;
-
-  @Column()
-  youtubeUrl: string;
-
-  @Column()
-  youtueMusicUrl: string | null;
-
   @OneToMany(() => Participant, (participant) => participant.artist)
   participants: Participant[];
+
+  @OneToMany(() => ChannelUrl, (channelUrl) => channelUrl.artist)
+  urls: ChannelUrl[];
 }

--- a/src/domain/artist/entity/channel-url.entity.ts
+++ b/src/domain/artist/entity/channel-url.entity.ts
@@ -1,0 +1,11 @@
+import { Entity, ManyToOne, PrimaryColumn } from "typeorm";
+import { Artist } from "./artist.entity";
+
+@Entity()
+export class ChannelUrl {
+  readonly name: string;
+  @PrimaryColumn()
+  readonly url: string;
+  @ManyToOne(() => Artist)
+  readonly artist: Artist;
+}

--- a/src/domain/artist/presentation/artist.controller.ts
+++ b/src/domain/artist/presentation/artist.controller.ts
@@ -1,7 +1,13 @@
-import { Controller } from "@nestjs/common";
+import { Controller, Get } from "@nestjs/common";
 import { ArtistService } from "../service/artist.service";
+import { AritstListResponse } from "../data/response/artist-list.response";
 
 @Controller("artists")
 export class ArtistController {
   constructor(private readonly artistService: ArtistService) {}
+
+  @Get()
+  async getArtists(): Promise<AritstListResponse> {
+    return await this.artistService.getArtist();
+  }
 }

--- a/src/domain/artist/presentation/artist.controller.ts
+++ b/src/domain/artist/presentation/artist.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from "@nestjs/common";
+import { ArtistService } from "../service/artist.service";
+
+@Controller("artists")
+export class ArtistController {
+  constructor(private readonly artistService: ArtistService) {}
+}

--- a/src/domain/artist/service/artist.service.ts
+++ b/src/domain/artist/service/artist.service.ts
@@ -16,13 +16,14 @@ export class ArtistService {
     const artistList = await this.artistRepository.find();
 
     const aristsResponseList = artistList.map((artist) => {
-      return new AritstResponse(
-        artist.id,
-        artist.name,
-        artist.chzzkUrl,
-        artist.youtubeUrl,
-        artist.youtueMusicUrl
-      );
+      const urlList = artist.urls.map((urlEntity) => {
+        return {
+          name: urlEntity.name,
+          url: urlEntity.url
+        };
+      });
+
+      return new AritstResponse(artist.id, artist.name, urlList);
     });
 
     return new AritstListResponse(aristsResponseList);

--- a/src/domain/artist/service/artist.service.ts
+++ b/src/domain/artist/service/artist.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from "@nestjs/common";
+import { Repository } from "typeorm";
+import { Artist } from "../entity/artist.entity";
+import { InjectRepository } from "@nestjs/typeorm";
+import { AritstResponse } from "../data/response/artist.response";
+import { AritstListResponse } from "../data/response/artist-list.response";
+
+@Injectable()
+export class ArtistService {
+  constructor(
+    @InjectRepository(Artist)
+    readonly artistRepository: Repository<Artist>
+  ) {}
+
+  async getArtist(): Promise<AritstListResponse> {
+    const artistList = await this.artistRepository.find();
+
+    const aristsResponseList = artistList.map((artist) => {
+      return new AritstResponse(
+        artist.id,
+        artist.name,
+        artist.chzzkUrl,
+        artist.youtubeUrl,
+        artist.youtueMusicUrl
+      );
+    });
+
+    return new AritstListResponse(aristsResponseList);
+  }
+}

--- a/src/domain/artist/service/artist.service.ts
+++ b/src/domain/artist/service/artist.service.ts
@@ -13,7 +13,7 @@ export class ArtistService {
   ) {}
 
   async getArtist(): Promise<AritstListResponse> {
-    const artistList = await this.artistRepository.find();
+    const artistList = await this.artistRepository.find({ relations: ["urls"] });
 
     const aristsResponseList = artistList.map((artist) => {
       const urlList = artist.urls.map((urlEntity) => {


### PR DESCRIPTION
## 개요
* 아티스트 조회 API를 추가합니다.
## 작업내용
* 아티스트 엔티티에 채널 url 필드 추가
* 아티스트 응답객체 추가
* ArtistService에 아티스트 조회 로직 추가
* ArtistController 추가
* 아티스트 조회 엔드포인트 추가
* ArtistController, ArtistService를 AppModule에 추가