### PR TITLE
🔀 :: [#52] - 신곡을 조회하는 API 추가

### DIFF
--- a/src/domain/music/presentation/music.controller.ts
+++ b/src/domain/music/presentation/music.controller.ts
@@ -22,4 +22,9 @@ export class MusicController {
   ): Promise<MusicChartListResponse> {
     return await this.musicService.getMusicChart(chartBy);
   }
+
+  @Get("new")
+  async getNewestMusic(): Promise<MusicListResponse> {
+    return await this.musicService.getNewestMusic();
+  }
 }

--- a/src/domain/music/service/music.service.ts
+++ b/src/domain/music/service/music.service.ts
@@ -97,4 +97,30 @@ export class MusicService {
     );
     return new MusicChartListResponse(musicChartResponseList);
   }
+
+  async getNewestMusic(): Promise<MusicListResponse> {
+    const musicList = await this.musicRepository.find({
+      relations: ["participants", "participants.artist"],
+      order: { uploadedDate: "DESC" },
+      take: 5
+    });
+
+    const musicResponseList = musicList.map((music) => {
+      const participantInfos = music.participants.map((pariticipant) => {
+        return new ParticipantInfo(pariticipant.artist.id, pariticipant.artist.name);
+      });
+      return new MusicResponse(
+        music.id,
+        music.name,
+        music.youtubeId,
+        music.views,
+        music.uploadedDate,
+        music.TJKaraokeCode,
+        music.KYKaraokeCode,
+        participantInfos
+      );
+    });
+
+    return new MusicListResponse(musicResponseList);
+  }
 }


### PR DESCRIPTION
## 개요
* 제일 최근에 업로드된 노래 5개를 조회하는 API를 추가합니다.
## 작업내용
* 신곡 조회 로직 추가
* 신곡 조회 엔드포인트 추가